### PR TITLE
Remove dust.helpers.tap - it's deprecated in dust helpers 1.6.2 and w…

### DIFF
--- a/dust/and.js
+++ b/dust/and.js
@@ -14,8 +14,8 @@ function initHelper(dust) {
 	dust.helpers.and = function(chunk, context, bodies, params) {
 		params = params || {};
 		var alternate = bodies.else;
-		var keys = dust.helpers.tap(params.keys, chunk, context);
-		var not = dust.helpers.tap(params.not, chunk, context);
+		var keys = context.resolve(params.keys);
+		var not = context.resolve(params.not);
 
 		var checkContext = function(arr) {
 			// jshint maxcomplexity: 7

--- a/dust/date-format.js
+++ b/dust/date-format.js
@@ -14,7 +14,7 @@ function initHelper(dust, renderer, config) {
 		params = params || {};
 
 		try {
-			value = (params.date) ? dust.helpers.tap(params.date, chunk, context) : null;
+			value = (params.date) ? context.resolve(params.date) : null;
 			date = (value) ? new Date(value.match(/^[0-9]+$/) ? parseInt(value, 10) : value) : new Date();
 			chunk.write(dateformat(date, params.format || 'yyyy-mm-dd'));
 		} catch (e) {

--- a/dust/number-format.js
+++ b/dust/number-format.js
@@ -4,7 +4,7 @@ module.exports = initHelper;
 
 function initHelper(dust) {
 	dust.helpers.numberFormat = function(chunk, context, bodies, params) {
-		var num = dust.helpers.tap(params.num, chunk, context);
+		var num = context.resolve(params.num);
 		if (num) {
 			return chunk.write(num.replace(/\B(?=(\d{3})+(?!\d))/g, ','));
 		}

--- a/dust/or.js
+++ b/dust/or.js
@@ -14,8 +14,8 @@ function initHelper(dust) {
 	dust.helpers.or = function(chunk, context, bodies, params) {
 		params = params || {};
 		var alternate = bodies.else;
-		var keys = dust.helpers.tap(params.keys, chunk, context);
-		var not = dust.helpers.tap(params.not, chunk, context);
+		var keys = context.resolve(params.keys);
+		var not = context.resolve(params.not);
 
 		var checkContext = function(arr) {
 			// jshint maxcomplexity: 7

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -28,7 +28,7 @@ module.exports = function(dust, renderer, config) {
 	};
 
 	dust.helpers.assetPath = function(chunk, context, bodies, params) {
-		var path = renderer.assetPath(dust.helpers.tap(params.src, chunk, context));
+		var path = renderer.assetPath(context.resolve(params.src));
 		if (!path) {
 			return chunk;
 		}


### PR DESCRIPTION
…ill be removed in 1.8

https://github.com/linkedin/dustjs-helpers/wiki/Deprecated-Features#tap
