### PR TITLE
Re-add the deprecated CLI options

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -41,16 +41,25 @@ module.exports = function(env, config, args) {
 			type: 'boolean'
 		})
 		.options('d', {
-			alias: 'source-directory',
+			alias: [
+				'source-directory',
+				'sourcedirectory'
+			],
 			default: process.cwd(),
 			type: 'string'
 		})
 		.options('o', {
-			alias: 'route-override',
+			alias: [
+				'route-override',
+				'routeoveride'
+			],
 			type: 'string'
 		})
 		.options('g', {
-			alias: 'origin-override',
+			alias: [
+				'origin-override',
+				'originoveride'
+			],
 			type: 'boolean'
 		})
 		.describe({


### PR DESCRIPTION
Otherwise we'd be introducing a breaking change. I've created a breaking issue #108 to remind us to remove these once we're ready for the next major bump.

yargs allows you to specify multiple aliases, and these all come through in the arguments. So if we have:

```js
.options('f', {
	alias: [
		'foo-bar',
		'foobar'
	]
})
```

and we run the command with:

```sh
mycommand --foobar baz
```

Then the returned `args` will have both properties (as well as a normalized camelCase one, which is there for convenience so you don't have to use square-bracket references):

```js
args == {
	'foo-bar': 'baz',
	foobar: 'baz',
	fooBar: 'baz'
};
```