### PR TITLE
More comprehensive route override  mapping

### DIFF
--- a/docs/usage/configuration-reference.md
+++ b/docs/usage/configuration-reference.md
@@ -223,7 +223,7 @@ Several aspects of Shunter behaviour can be configured via command line argument
  * `-r`, `--route-config` Sets the name of the default route, see [Routing](routing.md#route-config-options) for more details. Defaults to default.
  * `-s`, `--syslog` Turns on logging to syslog. Boolean.
  * `-d`, `--source-directory` Sets the root directory for your app, paths will be resolved from here. This setting is useful if you don't want to start your Shunter app from it's own directory. Defaults to the current working directory.
- * `-o`, `--route-override` Sets the proxy destination for all requests see [Routing](routing.md#route-config-options) for more details.
+ * `-o`, `--route-override` Sets the proxy destination for all requests see [Routing](routing.md#route-override) for more details.
  * `-g`, `--origin-override` Requires `--route-override`. Sets `changeOrigin: true` for the route set up via `--route-override`, see [Routing](routing.md#route-config-options) for more details.
  * `-v`, `--version` Prints the Shunter version number.
  * `-h`, `--help` Prints help about these options.

--- a/docs/usage/routing.md
+++ b/docs/usage/routing.md
@@ -4,6 +4,7 @@ Routing
 
 - [Examples](#examples)
 - [Route Config Options](#route-config-options)
+- [Route Override](#route-override)
 - [Change Origin](#change-origin)
 
 When Shunter receives an incoming request it needs to know where the request should be proxied to. This is configured by setting a `routes` property when you create your shunter app, typically by requiring a config file:
@@ -90,9 +91,20 @@ By default if none of the regex patterns are matched Shunter will use the route 
 
 And ran your Shunter app with `--route-config=custom` requests would be routed to port 1337 instead of 5000.
 
-Routing can be overridden entirely by setting the `route-override` option. Running your Shunter app with `--route-override=www.example.com:1337` would route all requests to that destination.
+
+Route Override
+-------------
+
+Routing can be overridden entirely by setting the `route-override` option. Running your Shunter app with `--route-override=http://www.example.com:1337` would route all requests to that destination. You could also route to an IPv4: `--route-override=8.8.8.8:80`
+
+**n.b**: You MUST specify the protocol `http` or `https` when setting a hostname using `route-override`
 
 You can use the `--origin-override` (`-g`) option in conjunction with the `route-override` option to set `changeOrigin: true` for the overriding route. See [Change Origin](#change-origin) for more details.
+
+This would be useful when deploying your Shunter app to a platform that makes use of environment variables. For example you could start up a Shunter app with:
+```
+node app -p $PORT --route-override=$BACKEND_APP --origin-override
+```
 
 
 Change Origin

--- a/docs/usage/routing.md
+++ b/docs/usage/routing.md
@@ -97,7 +97,21 @@ Route Override
 
 Routing can be overridden entirely by setting the `route-override` option. Running your Shunter app with `--route-override=http://www.example.com:1337` would route all requests to that destination. You could also route to an IPv4: `--route-override=8.8.8.8:80`
 
-**n.b**: You MUST specify the protocol `http` or `https` when setting a hostname using `route-override`
+**n.b**: If you do not specify a protocol (`http` or `https`) when setting a route via `route-override` then it will default to `http`. Please also note that `https` is currently unsupported by Shunter.
+```
+--route-override=$BACKEND_URL
+```
+| BACKEND_URL                   | Proxy Destination           |
+| :---------------------------- | :-------------------------- |
+| `http://www.example.com`      | `http://www.example.com`    |
+| `https://foo.example.com`     | `https://foo.example.com`   |
+| `www.example.com`             | `http://www.example.com`    |
+| `www.example.com:80`          | `http://www.example.com:80` |
+| `localhost`                   | `http://localhost`          |
+| `127.0.0.1:5000`              | `http://127.0.0.1:5000`     |
+| `8.8.8.8`                     | `http://8.8.8.8`            |
+| `https://8.8.8.8:80`          | `https://8.8.8.8:80`        |
+
 
 You can use the `--origin-override` (`-g`) option in conjunction with the `route-override` option to set `changeOrigin: true` for the overriding route. See [Change Origin](#change-origin) for more details.
 

--- a/lib/map-route.js
+++ b/lib/map-route.js
@@ -4,22 +4,23 @@
 module.exports = function(address) {
 	var url = require('url');
 
-	// Regular Expression Object matches against IPv4
-	var ipv4RegExp = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+	var parseUrl = function(address) {
+		var protocol = url.parse(address).protocol || null;
+
+		if (protocol === 'http:' || protocol === 'https:') {
+			return url.parse(address);
+		}
+
+		return url.parse('http://' + address);
+	};
 
 	var map = function(address) {
 		var mappedRoute = {};
-		var route;
+		var route = parseUrl(address);
 
-		if (ipv4RegExp.test(address.split(':')[0])) {
-			route = address.split(':');
-			mappedRoute.host = route[0] && route[0].length >= 7 ? route[0] : null;
-			mappedRoute.port = route[1] && route[1].length > 1 ? route[1] : null;
-		} else {
-			route = url.parse(address);
-			mappedRoute.host = route.hostname || null;
-			mappedRoute.port = route.port || null;
-		}
+		mappedRoute.protocol = route.protocol || null;
+		mappedRoute.host = route.hostname || null;
+		mappedRoute.port = route.port || null;
 
 		return mappedRoute;
 	};

--- a/lib/map-route.js
+++ b/lib/map-route.js
@@ -1,0 +1,28 @@
+
+'use strict';
+
+module.exports = function(address) {
+	var url = require('url');
+
+	// Regular Expression Object matches against IPv4
+	var ipv4RegExp = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+
+	var map = function(address) {
+		var mappedRoute = {};
+		var route;
+
+		if (ipv4RegExp.test(address.split(':')[0])) {
+			route = address.split(':');
+			mappedRoute.host = route[0] && route[0].length >= 7 ? route[0] : null;
+			mappedRoute.port = route[1] && route[1].length > 1 ? route[1] : null;
+		} else {
+			route = url.parse(address);
+			mappedRoute.host = route.hostname || null;
+			mappedRoute.port = route.port || null;
+		}
+
+		return mappedRoute;
+	};
+
+	return map(address);
+};

--- a/lib/router.js
+++ b/lib/router.js
@@ -2,6 +2,7 @@
 'use strict';
 
 module.exports = function(config) {
+	var extend = require('extend');
 	var mapRoute = require('./map-route');
 	var routes = config.routes;
 	var defaultRoute = config.argv['route-config'] || 'default';
@@ -15,10 +16,8 @@ module.exports = function(config) {
 	if (config.argv['route-override']) {
 		override = mapRoute(config.argv['route-override']);
 		if (override.host) {
-			localhost.host = override.host;
-			localhost.port = override.port || null;
 			routes = {localhost: {default: ''}};
-			routes.localhost.default = localhost;
+			routes.localhost.default = extend(true, {}, localhost, override);
 			defaultRoute = 'default';
 		}
 	}

--- a/lib/router.js
+++ b/lib/router.js
@@ -2,6 +2,7 @@
 'use strict';
 
 module.exports = function(config) {
+	var mapRoute = require('./map-route');
 	var routes = config.routes;
 	var defaultRoute = config.argv['route-config'] || 'default';
 	var localhost = {};
@@ -12,10 +13,10 @@ module.exports = function(config) {
 	}
 
 	if (config.argv['route-override']) {
-		override = config.argv['route-override'].split(':');
-		if (override[0].length > 7 && override[1].length > 1) {
-			localhost.host = override[0];
-			localhost.port = override[1];
+		override = mapRoute(config.argv['route-override']);
+		if (override.host) {
+			localhost.host = override.host;
+			localhost.port = override.port || null;
 			routes = {localhost: {default: ''}};
 			routes.localhost.default = localhost;
 			defaultRoute = 'default';

--- a/tests/server/core/map-route.js
+++ b/tests/server/core/map-route.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var assert = require('proclaim');
+
+var moduleName = '../../../lib/map-route';
+
+describe('Mapping a route', function() {
+
+	it('Should map a route with a protocol, hostname and port', function() {
+		var route = require(moduleName)('http://somehost-name.foo.com:80');
+		assert.equal(route.host, 'somehost-name.foo.com');
+		assert.equal(route.port, 80);
+	});
+
+	it('Should map a route with a protocol, subdomain, hostname and port', function() {
+		var route = require(moduleName)('https://foo-www.somehost-name.bar.com:80');
+		assert.equal(route.host, 'foo-www.somehost-name.bar.com');
+		assert.equal(route.port, 80);
+	});
+
+	it('Should map a route with a protocol, subdomain, hostname and no port', function() {
+		var route = require(moduleName)('http://somehost-name.foo.com');
+		assert.equal(route.host, 'somehost-name.foo.com');
+		assert.equal(route.port, null);
+	});
+
+	it('Should map a route with an IPv4 address and port', function() {
+		var route = require(moduleName)('127.0.0.1:9000');
+		assert.equal(route.host, '127.0.0.1');
+		assert.equal(route.port, 9000);
+	});
+
+	it('Should map a route with an IPv4 address and no port', function() {
+		var route = require(moduleName)('8.8.8.8');
+		assert.equal(route.host, '8.8.8.8');
+		assert.equal(route.port, null);
+	});
+
+	it('Should not map an invalid route hostname', function() {
+		var route = require(moduleName);
+		assert.equal(route('test').host, null);
+		assert.equal(route('foo.com').host, null);
+	});
+
+	it('Should not map an invalid route IPv4', function() {
+		var route = require(moduleName);
+		assert.equal(route('260.0.0.0').host, null);
+		assert.equal(route('1234').host, null);
+		assert.equal(route('a.0.0.1').host, null);
+		assert.equal(route('...1234').host, null);
+	});
+
+});

--- a/tests/server/core/map-route.js
+++ b/tests/server/core/map-route.js
@@ -7,47 +7,61 @@ var moduleName = '../../../lib/map-route';
 describe('Mapping a route', function() {
 
 	it('Should map a route with a protocol, hostname and port', function() {
-		var route = require(moduleName)('http://somehost-name.foo.com:80');
-		assert.equal(route.host, 'somehost-name.foo.com');
+		var route = require(moduleName)('http://www.foo.com:80');
+		assert.equal(route.protocol, 'http:');
+		assert.equal(route.host, 'www.foo.com');
 		assert.equal(route.port, 80);
 	});
 
 	it('Should map a route with a protocol, subdomain, hostname and port', function() {
 		var route = require(moduleName)('https://foo-www.somehost-name.bar.com:80');
+		assert.equal(route.protocol, 'https:');
 		assert.equal(route.host, 'foo-www.somehost-name.bar.com');
 		assert.equal(route.port, 80);
 	});
 
 	it('Should map a route with a protocol, subdomain, hostname and no port', function() {
 		var route = require(moduleName)('http://somehost-name.foo.com');
+		assert.equal(route.protocol, 'http:');
 		assert.equal(route.host, 'somehost-name.foo.com');
 		assert.equal(route.port, null);
 	});
 
 	it('Should map a route with an IPv4 address and port', function() {
 		var route = require(moduleName)('127.0.0.1:9000');
+		assert.equal(route.protocol, 'http:');
 		assert.equal(route.host, '127.0.0.1');
 		assert.equal(route.port, 9000);
 	});
 
 	it('Should map a route with an IPv4 address and no port', function() {
 		var route = require(moduleName)('8.8.8.8');
+		assert.equal(route.protocol, 'http:');
 		assert.equal(route.host, '8.8.8.8');
 		assert.equal(route.port, null);
 	});
 
-	it('Should not map an invalid route hostname', function() {
-		var route = require(moduleName);
-		assert.equal(route('test').host, null);
-		assert.equal(route('foo.com').host, null);
+	it('Should map a route with a protocol and a IPv4 address and a port', function() {
+		var route = require(moduleName)('https://8.8.8.8:80');
+		assert.equal(route.protocol, 'https:');
+		assert.equal(route.host, '8.8.8.8');
+		assert.equal(route.port, 80);
 	});
 
-	it('Should not map an invalid route IPv4', function() {
+	it('Should map a route with a protocol and a IPv4 address and no port', function() {
+		var route = require(moduleName)('https://8.8.8.8');
+		assert.equal(route.protocol, 'https:');
+		assert.equal(route.host, '8.8.8.8');
+		assert.equal(route.port, null);
+	});
+
+	it('Should default to mapping a hostname protocol to http', function() {
 		var route = require(moduleName);
-		assert.equal(route('260.0.0.0').host, null);
-		assert.equal(route('1234').host, null);
-		assert.equal(route('a.0.0.1').host, null);
-		assert.equal(route('...1234').host, null);
+		assert.equal(route('localhost').host, 'localhost');
+		assert.equal(route('localhost').protocol, 'http:');
+
+		assert.equal(route('foo.com').host, 'foo.com');
+		assert.equal(route('localhost').protocol, 'http:');
 	});
 
 });

--- a/tests/server/core/router.js
+++ b/tests/server/core/router.js
@@ -131,13 +131,62 @@ describe('Proxy routing', function() {
 		assert.equal(route.port, 22789);
 	});
 
-	it('Should set the default route from that specified in the config options', function() {
-		config.argv = {
-			'route-override': '127.0.0.1:9000'
-		};
-		var route = require(moduleName)(config).map('localhost', '/');
-		assert.equal(route.host, '127.0.0.1');
-		assert.equal(route.port, 9000);
+	describe('Should set the default route from that specified in the config options', function() {
+
+		it('Should set a route with a protocol, subdomain, hostname and port', function() {
+			config.argv = {
+				'route-override': 'https://foo-www.somehost-name.bar.com:80'
+			};
+			var route = require(moduleName)(config).map('localhost', '/');
+			assert.equal(route.host, 'foo-www.somehost-name.bar.com');
+			assert.equal(route.port, 80);
+		});
+
+		it('Should set a route with a protocol, hostname and no port', function() {
+			config.argv = {
+				'route-override': 'http://somehost-name.foo.com'
+			};
+			var route = require(moduleName)(config).map('localhost', '/');
+			assert.equal(route.host, 'somehost-name.foo.com');
+			assert.equal(route.port, null);
+		});
+
+		it('Should not set override if invalid route hostname', function() {
+			config.argv = {
+				'route-override': 'foobar'
+			};
+			var route = require(moduleName)(config).map('localhost', '/');
+			assert.equal(route.host, '127.0.0.1');
+			assert.equal(route.port, '5410');
+		});
+
+		it('Should set a route with an IPv4 address and port', function() {
+			config.argv = {
+				'route-override': '127.0.0.1:9000'
+			};
+			var route = require(moduleName)(config).map('localhost', '/');
+			assert.equal(route.host, '127.0.0.1');
+			assert.equal(route.port, 9000);
+		});
+
+		it('Should set a route with an IPv4 address and no port', function() {
+			config.argv = {
+				'route-override': '127.0.0.1'
+			};
+			var route = require(moduleName)(config).map('localhost', '/');
+			assert.equal(route.host, '127.0.0.1');
+			assert.equal(route.port, null);
+		});
+
+		it('Should not set override if invalid route ip', function() {
+			config.argv = {
+				'route-override': '1234'
+			};
+			var route = require(moduleName)(config).map('localhost', '/');
+			assert.equal(route.host, '127.0.0.1');
+			assert.equal(route.port, '5410');
+		});
+
 	});
 
 	it('Should set the default route and changeOrigin state if specified in the config options', function() {

--- a/tests/server/core/router.js
+++ b/tests/server/core/router.js
@@ -133,58 +133,34 @@ describe('Proxy routing', function() {
 
 	describe('Should set the default route from that specified in the config options', function() {
 
-		it('Should set a route with a protocol, subdomain, hostname and port', function() {
+		it('Should set a route with a protocol, hostname and port', function() {
 			config.argv = {
-				'route-override': 'https://foo-www.somehost-name.bar.com:80'
+				'route-override': 'https://foo.dev.bar-baz.com:80'
 			};
 			var route = require(moduleName)(config).map('localhost', '/');
-			assert.equal(route.host, 'foo-www.somehost-name.bar.com');
+			assert.equal(route.protocol, 'https:');
+			assert.equal(route.host, 'foo.dev.bar-baz.com');
 			assert.equal(route.port, 80);
 		});
 
-		it('Should set a route with a protocol, hostname and no port', function() {
-			config.argv = {
-				'route-override': 'http://somehost-name.foo.com'
-			};
-			var route = require(moduleName)(config).map('localhost', '/');
-			assert.equal(route.host, 'somehost-name.foo.com');
-			assert.equal(route.port, null);
-		});
-
-		it('Should not set override if invalid route hostname', function() {
-			config.argv = {
-				'route-override': 'foobar'
-			};
-			var route = require(moduleName)(config).map('localhost', '/');
-			assert.equal(route.host, '127.0.0.1');
-			assert.equal(route.port, '5410');
-		});
-
-		it('Should set a route with an IPv4 address and port', function() {
+		it('Should set a route with an IPv4 address and port, defaulting the protocol to http', function() {
 			config.argv = {
 				'route-override': '127.0.0.1:9000'
 			};
 			var route = require(moduleName)(config).map('localhost', '/');
+			assert.equal(route.protocol, 'http:');
 			assert.equal(route.host, '127.0.0.1');
 			assert.equal(route.port, 9000);
 		});
 
-		it('Should set a route with an IPv4 address and no port', function() {
+		it('Should set a route with a hostname defaulting the protocol to http', function() {
 			config.argv = {
-				'route-override': '127.0.0.1'
+				'route-override': 'localhost'
 			};
 			var route = require(moduleName)(config).map('localhost', '/');
-			assert.equal(route.host, '127.0.0.1');
+			assert.equal(route.protocol, 'http:');
+			assert.equal(route.host, 'localhost');
 			assert.equal(route.port, null);
-		});
-
-		it('Should not set override if invalid route ip', function() {
-			config.argv = {
-				'route-override': '1234'
-			};
-			var route = require(moduleName)(config).map('localhost', '/');
-			assert.equal(route.host, '127.0.0.1');
-			assert.equal(route.port, '5410');
 		});
 
 	});


### PR DESCRIPTION
This fixes an issue where setting a route via the override flag
to a hostname with a protocol would fall through back to default
config routing. It is fixed with more robust validating and
setting of the host and/or port.

However this does introduce a requirement that route overrides
using a hostname MUST set a protocol, which is good practice.
This is due to how Node.js url.parse() works.

 - new route mapping function and tests
 - adjustments to the router to adopt new function
 - use Node.js url.parse() to parse a url
 - validate IPv4 routes
 - fix bug where a valid ip address of 7 characters (8.8.8.8)
   would be ignored
 - update README to reflect changes and add example of how route
   override might be useful


**see the updated docs: https://github.com/springernature/shunter/blob/route-override-fix/docs/usage/routing.md#route-override**