### PR TITLE
Use Buffer concatenation to build response data

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -53,7 +53,7 @@ module.exports = function(config, renderer) {
 
 		intercept: function(req, res, next) {
 			// jscs:disable disallowDanglingUnderscores
-			var data = '';
+			var data = [];
 			var status = null;
 
 			var shouldIntercept = function() {
@@ -80,7 +80,7 @@ module.exports = function(config, renderer) {
 				}
 			};
 			var write = function(chunk) {
-				data += chunk.toString();
+				data.push(chunk);
 			};
 			var end = function() {
 				var timer = config.timer();
@@ -88,10 +88,10 @@ module.exports = function(config, renderer) {
 				if (req.__proxyTimingFunctionBodyReceived) {
 					statsd.timing('proxy_body_received', req.__proxyTimingFunctionBodyReceived('Received body ' + req.url));
 				}
+				var rawJson = Buffer.concat(data).toString('utf8');
+				var json = parseJson(rawJson);
 
-				var json = parseJson(data);
-
-				statsd.classifiedGauge(req.url, 'json_size', Buffer.byteLength(data));
+				statsd.classifiedGauge(req.url, 'json_size', Buffer.byteLength(rawJson));
 				statsd.classifiedTiming(req.url, 'parsing', timer('Parsing JSON ' + req.url));
 
 				res.writeHead = res.__originalWriteHead;

--- a/tests/server/core/processor.js
+++ b/tests/server/core/processor.js
@@ -162,7 +162,7 @@ describe('Request processor', function() {
 			processor.intercept(req, res, callback);
 
 			res.writeHead();
-			res.write('{"foo":"bar"}');
+			res.write(new Buffer('{"foo":"bar"}'));
 			res.end();
 
 			assert.isTrue(renderer.render.calledOnce);
@@ -186,7 +186,7 @@ describe('Request processor', function() {
 			processor.intercept(req, res, callback);
 
 			res.writeHead();
-			res.write('{"foo":"bar"}');
+			res.write(new Buffer('{"foo":"bar"}'));
 			res.end();
 
 			assert.isTrue(renderer.render.calledOnce);
@@ -216,7 +216,7 @@ describe('Request processor', function() {
 			processor.intercept(req, res, callback);
 
 			res.writeHead();
-			res.write('{"foo":"bar"}');
+			res.write(new Buffer('{"foo":"bar"}'));
 			res.end();
 
 			assert.equal(renderer.render.callCount, 0);
@@ -243,7 +243,7 @@ describe('Request processor', function() {
 			processor.intercept(req, res, callback);
 
 			res.writeHead();
-			res.write('{"foo":"bar"}');
+			res.write(new Buffer('{"foo":"bar"}'));
 			res.end();
 
 			renderer.render.firstCall.yield(null, 'Content');
@@ -274,7 +274,7 @@ describe('Request processor', function() {
 			processor.intercept(req, res, callback);
 
 			res.writeHead(401);
-			res.write('{"foo":"bar"}');
+			res.write(new Buffer('{"foo":"bar"}'));
 			res.end();
 
 			renderer.render.firstCall.yield(null, 'Content');
@@ -311,7 +311,7 @@ describe('Request processor', function() {
 			processor.intercept(req, res, callback);
 
 			res.writeHead();
-			res.write('{"foo":bar"}');
+			res.write(new Buffer('{"foo":bar"}'));
 			assert.doesNotThrow(function() {
 				res.end();
 			});


### PR DESCRIPTION
Also converting to string with utf8 set explicitly.

Hoping this should fix the sporadic multi-byte character corruption reported in https://github.com/springernature/shunter/issues/118