### PR TITLE
Removes deprecated content type

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -59,7 +59,7 @@ module.exports = function(config, renderer) {
 			var shouldIntercept = function() {
 				var type = res.getHeader('Content-type');
 				var method = req.method ? req.method.toUpperCase() : 'GET';
-				var acceptedType = type && (type.indexOf('x-shunter+json') !== -1 || type.indexOf('x-shunter-json') !== -1);
+				var acceptedType = type && (type.indexOf('x-shunter+json') !== -1);
 				var acceptedMethod = method === 'GET' || method === 'POST';
 
 				return acceptedType && acceptedMethod;

--- a/tests/server/core/processor.js
+++ b/tests/server/core/processor.js
@@ -145,30 +145,6 @@ describe('Request processor', function() {
 			assert.isTrue(res.__originalWriteHead.calledOnce);
 		});
 
-		it('Should intercept responses with an x-shunter-json mime type', function() {
-			var tier = sinon.stub();
-			var processor = require(moduleName)({
-				env: {
-					tier: tier
-				},
-				argv: {},
-				timer: mockTimer
-			}, renderer);
-			var callback = sinon.stub();
-
-			var req = {url: '/test/url'};
-
-			res.getHeader.withArgs('Content-type').returns('application/x-shunter-json');
-			processor.intercept(req, res, callback);
-
-			res.writeHead();
-			res.write(new Buffer('{"foo":"bar"}'));
-			res.end();
-
-			assert.isTrue(renderer.render.calledOnce);
-			assert.equal(renderer.render.firstCall.args[2].foo, 'bar');
-		});
-
 		it('Should intercept responses with an x-shunter+json mime type', function() {
 			var tier = sinon.stub();
 			var processor = require(moduleName)({


### PR DESCRIPTION
Removes logic that checks for the existence of 'x-shunter-json' content-type and associated tests.