### PR TITLE
Remove the command line option --deploy-timestamp-header

### DIFF
--- a/docs/usage/configuration-reference.md
+++ b/docs/usage/configuration-reference.md
@@ -227,7 +227,6 @@ Several aspects of Shunter behaviour can be configured via command line argument
  * `-g`, `--origin-override` Requires `--route-override`. Sets `changeOrigin: true` for the route set up via `--route-override`, see [Routing](routing.md#route-config-options) for more details.
  * `--rewrite-redirect` Sets `autoRewrite` option on the proxy, see the [Node HTTP Proxy documentation](https://github.com/nodejitsu/node-http-proxy#options) for more details.
  * `--rewrite-protocol` Sets the `protocolRewrite` option on the proxy, see the [Node HTTP Proxy documentation](https://github.com/nodejitsu/node-http-proxy#options) for more details.
- * `--deploy-timestamp-header` Proxy the timestamp of the last deploy of your Shunter application to the backend in an `X-Shunter-Deploy-Timestamp` header instead of a `shunter` query parameter.
  * `-v`, `--version` Prints the Shunter version number.
  * `-h`, `--help` Prints help about these options.
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -59,9 +59,6 @@ module.exports = function(env, config, args) {
 		.options('rewrite-protocol', {
 			type: 'string'
 		})
-		.options('deploy-timestamp-header', {
-			type: 'boolean'
-		})
 		.describe({
 			p: 'Port number',
 			m: 'Maximum size for request body in bytes',
@@ -72,8 +69,7 @@ module.exports = function(env, config, args) {
 			g: 'Requires --route-override. Sets changeOrigin to true for the route set up via --route-override',
 			d: 'Specify the directory for the main app if you are not running it from its own directory',
 			'rewrite-redirect': 'Rewrite the location host/port on 301, 302, 307 & 308 redirects based on requested host/port',
-			'rewrite-protocol': 'Rewrite the location protocol on 301, 302, 307 & 308 redirects to http or https',
-			'deploy-timestamp-header': 'Proxy the timestamp of the last deploy in a header instead of as a query parameter'
+			'rewrite-protocol': 'Rewrite the location protocol on 301, 302, 307 & 308 redirects to http or https'
 		})
 		.alias('h', 'help')
 		.help()

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -7,7 +7,6 @@ module.exports = function(config, renderer) {
 	var httpProxy = require('http-proxy');
 	var rewriteRedirect = config.argv['rewrite-redirect'] || false;
 	var protocolRewrite = config.argv['rewrite-protocol'] || null;
-	var deployTimestampHeader = config.argv['deploy-timestamp-header'] || false;
 	var proxy = httpProxy.createProxyServer({
 		autoRewrite: rewriteRedirect,
 		protocolRewrite: protocolRewrite
@@ -35,14 +34,7 @@ module.exports = function(config, renderer) {
 
 	var processor = {
 		timestamp: function(req, res, next) {
-			if (deployTimestampHeader) {
-				req.headers['X-Shunter-Deploy-Timestamp'] = deployTimestamp;
-			} else {
-				var separator = (req.url.indexOf('?') === -1) ? '?' : '&';
-				if (req.url.indexOf('shunter=') === -1) {
-					req.url += separator + 'shunter=' + deployTimestamp;
-				}
-			}
+			req.headers['X-Shunter-Deploy-Timestamp'] = deployTimestamp;
 			next();
 		},
 

--- a/tests/server/core/processor.js
+++ b/tests/server/core/processor.js
@@ -70,28 +70,7 @@ describe('Request processor', function() {
 			req = require('../mocks/request');
 		});
 
-		it('Should append the deployment timestamp to the request url', function() {
-			var processor = require(moduleName)(mockConfig, {});
-			var next = sinon.stub();
-
-			req.url = '/foo';
-			processor.timestamp(req, {}, next);
-			assert.equal(req.url, '/foo?shunter=1234567890');
-			assert.isTrue(next.calledOnce);
-		});
-
-		it('Should append the deployment timestamp to the request url when it has query parameters', function() {
-			var processor = require(moduleName)(mockConfig, {});
-			var next = sinon.stub();
-
-			req.url = '/foo?bar=baz';
-			processor.timestamp(req, {}, next);
-			assert.equal(req.url, '/foo?bar=baz&shunter=1234567890');
-			assert.isTrue(next.calledOnce);
-		});
-
-		it('Should add a header X-Shunter-Deploy-Timestamp with the deployment timestamp if configured to do so', function() {
-			mockConfig.argv['deploy-timestamp-header'] = true;
+		it('Should add a header X-Shunter-Deploy-Timestamp with the deployment timestamp', function() {
 			var processor = require(moduleName)(mockConfig, {});
 			var next = sinon.stub();
 


### PR DESCRIPTION
This ex-CLI option is now the default behaviour, as per https://github.com/springernature/shunter/issues/121