### PR TITLE
Correct/codify the Node.js versions that 4.0 supports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,9 @@ language: node_js
 matrix:
   include:
 
-    # Run lint only in Node.js 0.12
-    - node_js: '0.12'
+    # Run lint only in Node.js 6.x
+    - node_js: '6'
       env: LINT=true
-
-    # Run tests in Node.js 0.10
-    - node_js: '0.10'
-
-    # Run tests in Node.js 0.12
-    - node_js: '0.12'
 
     # Run tests in Node.js 4.x (dependencies require GCC 4.8)
     - node_js: '4'
@@ -26,6 +20,16 @@ matrix:
 
     # Run tests in Node.js 5.x (dependencies require GCC 4.8)
     - node_js: '5'
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.8
+            - g++-4.8
+
+    # Run tests in Node.js 6.x (dependencies require GCC 4.8)
+    - node_js: '6'
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,35 +8,23 @@ matrix:
     - node_js: '6'
       env: LINT=true
 
-    # Run tests in Node.js 4.x (dependencies require GCC 4.8)
+    # Run tests in Node.js 4.x
     - node_js: '4'
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-4.8
-            - g++-4.8
 
-    # Run tests in Node.js 5.x (dependencies require GCC 4.8)
+    # Run tests in Node.js 5.x
     - node_js: '5'
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-4.8
-            - g++-4.8
 
-    # Run tests in Node.js 6.x (dependencies require GCC 4.8)
+    # Run tests in Node.js 6.x
     - node_js: '6'
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-4.8
-            - g++-4.8
+
+# Dependencies require GCC 4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.8
+      - g++-4.8
 
 # Restrict builds on branches
 branches:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can also refer to the [API Documentation](docs/usage/index.md) for a full br
 Requirements
 ------------
 
-Shunter requires [Node.js][node] 0.10–5.x, which should come with [npm][npm]. This should be easy to get running on Mac and Linux.
+Shunter requires [Node.js][node] 4.x–6.x, which should come with [npm][npm]. This should be easy to get running on Mac and Linux.
 
 On Windows things are a bit more complicated due to the Shunter install process requiring a C compiler. Here are some useful links to help you:
 
@@ -79,6 +79,6 @@ Copyright &copy; 2015, Springer Nature
 [shield-coverage]: https://img.shields.io/coveralls/springernature/shunter.svg
 [shield-dependencies]: https://img.shields.io/gemnasium/springernature/shunter.svg
 [shield-license]: https://img.shields.io/badge/license-LGPL%203.0-blue.svg
-[shield-node]: https://img.shields.io/badge/node.js%20support-0.10–5-brightgreen.svg
+[shield-node]: https://img.shields.io/badge/node.js%20support-4–6-brightgreen.svg
 [shield-npm]: https://img.shields.io/npm/v/shunter.svg
 [shield-build]: https://img.shields.io/travis/springernature/shunter/master.svg

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ Getting Started with Shunter
 
 This guide will teach you how to put together a basic application with Shunter. [API Documentation](usage/index.md) is also available if you need more detail.
 
-Before we begin, you'll need to have [Node.js](https://nodejs.org/) installed, Shunter requires Node.js 0.10–5.x.
+Before we begin, you'll need to have [Node.js](https://nodejs.org/) installed, Shunter requires Node.js 4.x–6.x.
 
 This guide will not explain every feature of Shunter. Its aim is to get you up-and-running in as little time as possible.
 


### PR DESCRIPTION
I noticed that we missed a few places when we tweaked Node.js version support. This updates the documentation and CI config to specify the correct versions.