### PR TITLE
Fix accidentally skipped dependency updates for async and gaze

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"node": ">=4 <=6"
 	},
 	"dependencies": {
-		"async": "~1.4",
+		"async": "~2.0",
 		"body-parser": "~1.15",
 		"cheerio": "~0.20",
 		"connect": "~3.4",
@@ -56,7 +56,7 @@
 		"each-module": "~1.2",
 		"ejs": "~2.5",
 		"extend": "~3.0",
-		"gaze": "~0.5",
+		"gaze": "~1.0",
 		"glob": "~7.0",
 		"hasbin": "~1.2",
 		"http-proxy": "~1.14",


### PR DESCRIPTION
Somehow I accidentally skipped incrementing the async and gaze version numbers in the v4.0 release.  This commit sets them to the version they should have been.