### PR TITLE
hikes wd dependency to ~1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"serve-static": "~1.11",
 		"statsd-client": "~0.2",
 		"uglify-js": "~2.7",
-		"wd": "~0.4",
+		"wd": "~1.0",
 		"winston": "~2.2",
 		"winston-syslog": "~1.2",
 		"yargs": "~4.8"


### PR DESCRIPTION
Output from `$ nsp check --output summary`
```
  (+) 3 vulnerabilities found
  Name        Installed   Patched                      Path                                                                                                            More Info
  hawk        2.3.1       >=3.1.3 < 4.0.0 || >=4.1.1   frontend-springer-transfer@1.0.0 > shunter@4.0.2 > wd@0.4.0 > request@2.55.0 > hawk@2.3.1                       https://nodesecurity.io/advisories/77
  minimatch   2.0.10      >=3.0.2                      frontend-springer-transfer@1.0.0 > shunter@4.0.2 > wd@0.4.0 > archiver@0.14.4 > glob@4.3.5 > minimatch@2.0.10   https://nodesecurity.io/advisories/118
...
```
3rd vuln snipped as we can't do anything about it yet...
From the [wd release notes](https://github.com/admc/wd/blob/master/doc/release-notes.md) this looks like an OK upgrade.  Tests pass, and a quick check in my current shunter project looked ok.
