### PR TITLE
Add ability to set logging level via command line, move some log messages to debug

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -112,7 +112,7 @@ app.start();
 When we run this file using `node app.js`, you should see a short delay then a message like this:
 
 ```
-Shunter started with 4 child processes listening
+Shunter started with X child processes listening
 ```
 
 If you open up [http://localhost:5400/](http://localhost:5400/) in your browser, you should see a blank page in your browser and get some error messages in your terminal window. That's because we haven't got a back end running yet.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,10 +109,10 @@ var app = shunter({
 app.start();
 ```
 
-When we run this file using `node app.js`, you should see a bunch of logs ending with a message like this:
+When we run this file using `node app.js`, you should see a short delay then a message like this:
 
 ```
-All child processes listening
+Shunter started with 4 child processes listening
 ```
 
 If you open up [http://localhost:5400/](http://localhost:5400/) in your browser, you should see a blank page in your browser and get some error messages in your terminal window. That's because we haven't got a back end running yet.

--- a/docs/usage/configuration-reference.md
+++ b/docs/usage/configuration-reference.md
@@ -104,12 +104,15 @@ Log Configuration
 
 The log object defines the tool that Shunter should use for logging. By default Shunter uses [Winston](https://github.com/winstonjs/winston).
 
+You can specify the logging level to use (e.g. 'info' the default, or 'debug' if you'd like to see more) by using the `-l` [command line option](#command-line-options)
+
 ```js
 log: new winston.Logger({
     transports: [
         new (winston.transports.Console)({
             colorize: true,
-            timestamp: true
+            timestamp: true,
+            level: args.logging
         })
     ]
 }),
@@ -221,6 +224,7 @@ Several aspects of Shunter behaviour can be configured via command line argument
  * `-m`, `--max-post-size` Sets the maximum size in bytes for the Shunter API, defaults to 204800.
  * `-c`, `--max-child-processes` When Shunter runs it spawns child worker processes to handle requests, this option sets the maximum number of child processes it will create. It defaults to 10, but will never exceed the number of CPU cores you have available.
  * `-r`, `--route-config` Sets the name of the default route, see [Routing](routing.md#route-config-options) for more details. Defaults to default.
+ * `-l`, `--logging` Sets the logging level for your configured logger (e.g. 'error', 'warn', 'info', 'debug').  Defaults to 'info'.
  * `-s`, `--syslog` Turns on logging to syslog. Boolean.
  * `-d`, `--source-directory` Sets the root directory for your app, paths will be resolved from here. This setting is useful if you don't want to start your Shunter app from it's own directory. Defaults to the current working directory.
  * `-o`, `--route-override` Sets the proxy destination for all requests see [Routing](routing.md#route-override) for more details.

--- a/lib/config.js
+++ b/lib/config.js
@@ -36,6 +36,11 @@ module.exports = function(env, config, args) {
 			alias: 'route-config',
 			default: 'default'
 		})
+		.options('l', {
+			alias: 'logging',
+			default: 'info',
+			type: 'string'
+		})
 		.options('s', {
 			alias: 'syslog',
 			type: 'boolean'
@@ -71,6 +76,7 @@ module.exports = function(env, config, args) {
 			m: 'Maximum size for request body in bytes',
 			c: 'Shunter will create one worker process per cpu available up to this maximum',
 			r: 'Specify the name of the default route from your route config file',
+			l: 'Set logging level',
 			s: 'Enable logging to syslog',
 			o: 'Specify host and port to override or replace route config file',
 			g: 'Requires --route-override. Sets changeOrigin to true for the route set up via --route-override',
@@ -148,7 +154,8 @@ module.exports = function(env, config, args) {
 			transports: [
 				new (winston.transports.Console)({
 					colorize: true,
-					timestamp: true
+					timestamp: true,
+					level: args.logging
 				})
 			]
 		}),
@@ -161,7 +168,7 @@ module.exports = function(env, config, args) {
 			var start = Date.now();
 			return function(msg) {
 				var diff = Date.now() - start;
-				config.log.info(msg + ' - ' + diff + 'ms');
+				config.log.debug(msg + ' - ' + diff + 'ms');
 				return diff;
 			};
 		},
@@ -189,7 +196,8 @@ module.exports = function(env, config, args) {
 		require('winston-syslog');
 		config.log.add(winston.transports.Syslog, {
 			localhost: hostname,
-			app_name: config.syslogAppName
+			app_name: config.syslogAppName,
+			level: 'debug'
 		});
 	}
 	return config;

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -225,7 +225,7 @@ module.exports = function(config) {
 			watcher = watchTree(folders, config.log);
 			watcher.on('fileModified', compile);
 			watcher.on('fileCreated', compile);
-			config.log.info('Watching ' + folders.join(', ') + ' for changes');
+			config.log.debug('Watching ' + folders.join(', ') + ' for changes');
 		},
 
 		watchDustExtensions: function() {
@@ -247,7 +247,7 @@ module.exports = function(config) {
 			watcher = watchTree(folders, config.log);
 			watcher.on('fileModified', compile);
 			watcher.on('fileCreated', compile);
-			config.log.info('Watching ' + folders.join(', ') + ' for changes');
+			config.log.debug('Watching ' + folders.join(', ') + ' for changes');
 		},
 
 		render: function(req, res, data, callback) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -66,13 +66,13 @@ module.exports = function(config) {
 			if (err) {
 				config.log.error('Error saving shunter.pid file for process ' + pid + ' ' + (err.message || err.toString()));
 			} else {
-				config.log.info('Saved shunter.pid file for process ' + pid);
+				config.log.debug('Saved shunter.pid file for process ' + pid);
 			}
 		});
 	};
 
 	var clearProcessId = function() {
-		config.log.info('Deleting old shunter.pid file');
+		config.log.debug('Deleting old shunter.pid file');
 		fs.unlinkSync(path.join(config.path.root, 'shunter.pid'));
 	};
 
@@ -86,23 +86,24 @@ module.exports = function(config) {
 		},
 		start: function() {
 			if (cluster.isMaster) {
+				var childProcesses = Math.min(
+					require('os').cpus().length,
+					config.argv['max-child-processes']
+				);
 				saveTimestamp();
 				saveProcessId();
 
-				init(Math.min(
-					require('os').cpus().length,
-					config.argv['max-child-processes']
-				), function() {
-					config.log.info('All child processes listening');
+				init(childProcesses, function() {
+					config.log.info('Shunter started with ' + childProcesses + ' child processes listening');
 				});
 
 				process.on('SIGUSR2', function() {
-					config.log.info('SIGUSR2 received, reloading all workers');
+					config.log.debug('SIGUSR2 received, reloading all workers');
 					saveTimestamp();
 					restart();
 				});
 				process.on('SIGINT', function() {
-					config.log.info('SIGINT received, exiting...');
+					config.log.debug('SIGINT received, exiting...');
 					process.exit(0);
 				});
 				process.on('exit', function() {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -52,7 +52,7 @@ module.exports = function(config) {
 	app.use(processor.proxy);
 
 	app.listen(config.argv.port, function() {
-		config.log.info('Worker process ' + process.pid + ' started in ' + config.env.name + ' mode, listening on port ' + config.argv.port);
+		config.log.debug('Worker process ' + process.pid + ' started in ' + config.env.name + ' mode, listening on port ' + config.argv.port);
 	});
 	process.on('uncaughtException', function(err) {
 		if (err.code === 'EADDRINUSE') {

--- a/tests/server/core/server.js
+++ b/tests/server/core/server.js
@@ -71,7 +71,7 @@ describe('Clustering', function() {
 			require('os').cpus.returns([1, 1]);
 			server.start();
 			cluster.fork().on.yield();
-			assert.isTrue(config.log.info.calledWith('All child processes listening'));
+			assert.isTrue(config.log.info.calledWith('Shunter started with 2 child processes listening'));
 		});
 
 		it('Should save the a pid file on start up', function() {
@@ -80,7 +80,7 @@ describe('Clustering', function() {
 			server.start();
 			fs.writeFile.yield();
 			assert.isTrue(fs.writeFile.calledWith('/shunter.pid', process.pid));
-			assert.isTrue(config.log.info.calledWith('Saved shunter.pid file for process ' + process.pid));
+			assert.isTrue(config.log.debug.calledWith('Saved shunter.pid file for process ' + process.pid));
 		});
 
 		it('Should log an error if it was unable to write the pid file', function() {
@@ -109,7 +109,7 @@ describe('Clustering', function() {
 			require('os').cpus.returns([1, 1, 1]);
 			server.start();
 			process.on.withArgs('SIGUSR2').firstCall.yield();
-			assert.isTrue(config.log.info.calledWith('SIGUSR2 received, reloading all workers'));
+			assert.isTrue(config.log.debug.calledWith('SIGUSR2 received, reloading all workers'));
 		});
 
 		it('Should save the timestamp when SIGUSR2 is captured', function() {

--- a/tests/server/core/worker.js
+++ b/tests/server/core/worker.js
@@ -84,7 +84,7 @@ describe('Worker process running in production', function() {
 	});
 	afterEach(function() {
 		process.exit.reset();
-		config.log.info.reset();
+		config.log.debug.reset();
 	});
 
 	it('Should listen for exit messages', function() {
@@ -191,7 +191,7 @@ describe('Worker process running in production', function() {
 
 	it('Should log a message on start up', function() {
 		connect().listen.firstCall.yield();
-		assert.isTrue(config.log.info.calledOnce);
+		assert.isTrue(config.log.debug.calledOnce);
 	});
 });
 


### PR DESCRIPTION
I find shunter to be quite verbose by default, particularly when starting up.  To help combat this, but preserve those log messages for when they may be useful (during debugging), I've introduced a new command line option `-l` or `--logging` which can be used to set the logging level.

I've also downgraded many of the most prolific (and I think least significant) logging messages from `info` to `debug`.

This means that when starting up a shunter application and shutting one down, you now just get one console message to notify completion of each.  Any proxied request through the app will also only output a single message to acknowledge the request.

Note I have still kept syslog logging at a `debug` level by default right now (to avoid a possibly disruptive change).  We may want to consider changing that or allowing `-s` `--syslog` to operate in a similar way.