### PR TITLE
Add Snyk CI integration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,10 @@ trim_trailing_whitespace = true
 [*.json]
 insert_final_newline = false
 
+[package.json]
+indent_style = space
+indent_size = 2
+
 [*.md]
 indent_style = space
 trim_trailing_whitespace = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,4 @@ script:
 
 # Updates the dashboard after a successful deployment
 after_success:
-  - snyk monitor
+  - snyk monitor --org=springer-nature

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,7 @@ branches:
 script:
   - 'if [ $LINT ]; then make lint; fi'
   - 'if [ ! $LINT ]; then make lcov-levels; fi'
+
+# Updates the dashboard after a successful deployment
+after_success:
+  - snyk monitor

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,12 @@ jscs:
 	@./node_modules/.bin/jscs .
 
 # Run all tests
-test: test-server
+test: snyk-test test-server
+
+# Run snyk test
+snyk-test:
+	@echo "$(C_CYAN)> running 'snyk test'$(C_RESET)"
+	@./node_modules/.bin/snyk test
 
 # Run unit tests
 test-server:

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "mocha": "^3.0.0",
     "mockery": "^2.0.0",
     "proclaim": "^3.0.0",
-    "sinon": "^2.0.0"
+    "sinon": "^2.0.0",
+    "snyk": "^1.29.0"
   },
 
   "main": "./lib/shunter.js",


### PR DESCRIPTION
This ensures that `snyk test` runs on every build, even if we were to commit straight to master. Very simple, just a few changes:
* Add editorconfig rules for the package.json file, which were missing (unrelated to this change but not big enough to deserve a separate PR)
* Add snyk as devDependency so it can run at build time.
* Add `snyk test` to the Makefile. There's a new `make snyk-test` command that will run as part or the `make test` or `npm test` commands.
* Add `snyk monitor` after a successful deployment. This will ensure that a test is triggered and the snyk dashboard is updated.

This is the first example of the behaviour that we discussed in the open space a few weeks ago (we wanted snyk integration both in github's PRs and in whatever CI system we're using, so it doesn't matter if we're using PRs or not).