### PR TITLE
Phase one of the jshint/jscs to eslint/xo move

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,12 @@ deps:
 	@npm install
 
 # Run all linters
-lint: jshint jscs
+lint: xo
 
 # Lint JavaScript
-jshint:
+xo:
 	@echo "$(C_CYAN)> linting javascript$(C_RESET)"
-	@./node_modules/.bin/jshint .
-
-# Run JavaScript Code Style
-jscs:
-	@echo "$(C_CYAN)> checking javascript code style$(C_RESET)"
-	@./node_modules/.bin/jscs .
+	@./node_modules/.bin/xo
 
 # Run all tests
 test: snyk-test test-server

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
-var jserve = require('jserve');
 var path = require('path');
+var jserve = require('jserve');
 var query = require('qs-middleware');
 var request = require('request');
 var yargs = require('yargs');
@@ -91,7 +91,7 @@ function serveRemoteJson(request, response, next) {
 
 	options.headers = parseHeaders(options.headers);
 
-	loadRemoteJson(options, function(error, json) {
+	loadRemoteJson(options, function (error, json) {
 		if (error) {
 			return next(error);
 		}
@@ -108,8 +108,8 @@ function loadRemoteJson(options, done) {
 		url: options.url,
 		headers: options.headers
 	};
-	request(requestOptions, function(error, response, body) {
-		if (error) {
+	request(requestOptions, function (err, response, body) {
+		if (err) {
 			return done(error);
 		}
 		if (response.statusCode < 200 || response.statusCode >= 300) {
@@ -119,8 +119,8 @@ function loadRemoteJson(options, done) {
 		}
 		try {
 			body = JSON.parse(body);
-		} catch (error) {
-			return done(error);
+		} catch (err) {
+			return done(err);
 		}
 		done(null, body);
 	});
@@ -130,7 +130,7 @@ function loadRemoteJson(options, done) {
 function parseHeaders(headerString) {
 	var headers = {};
 	var headersArray = headerString.split(/[\r\n]+/);
-	headersArray.forEach(function(headerString) {
+	headersArray.forEach(function (headerString) {
 		var headerChunks = headerString.split(':');
 		headers[headerChunks.shift().trim()] = headerChunks.join(':').trim();
 	});

--- a/bin/test-client.js
+++ b/bin/test-client.js
@@ -44,13 +44,10 @@ This script starts up a server, so you don't have to already have one running.
 
 'use strict';
 
-(function() {
-	// jshint maxstatements: false
-	// jscs:disable requireCamelCaseOrUpperCaseIdentifiers
-
+(function () {
 	var fs = require('fs');
 	var path = require('path');
-	var shell = require('child_process').exec; // used for triggering mocha-phantomjs. do not pass user input to this.
+	var shell = require('child_process').exec; // Used for triggering mocha-phantomjs. do not pass user input to this.
 	var connect = require('connect');
 	var serveStatic = require('serve-static');
 	var yargs = require('yargs');
@@ -104,7 +101,7 @@ This script starts up a server, so you don't have to already have one running.
 		firefox: 2,
 		'internet explorer': 8, // IE7 times out without managing to invoke any tests
 		safari: 4.1
-		// opera: 10, // Fails with java.lang.UnsupportedOperationException
+		// Opera: 10, // Fails with java.lang.UnsupportedOperationException
 		// iphone: 4.3, // Tests hang part-way through and eventually time out
 		// android: 2.3 // Fails with java.lang.UnsupportedOperationException
 	};
@@ -115,16 +112,16 @@ This script starts up a server, so you don't have to already have one running.
 		return runTests();
 	}
 
-	// dust template setup
+	// Dust template setup
 	renderer.compileFile(path.join(__dirname, '..', 'view', 'test-runner.dust'));
-	// middleware
+	// Middleware
 	var app = startApp();
 	app.listen(port, runTests);
 
 	/*
 		Get script block for processed main.js file via Mincer
 	*/
-	renderer.dust.helpers.scriptBlock = function(chunk, context, bodies, params) {
+	renderer.dust.helpers.scriptBlock = function (chunk, context, bodies, params) {
 		var assetPath;
 		var asset = renderer.environment.findAsset(params.src);
 		if (!asset) {
@@ -137,23 +134,23 @@ This script starts up a server, so you don't have to already have one running.
 	/*
 		Get the correct group of test files
 	*/
-	renderer.dust.helpers.scriptSpecs = function(chunk) {
+	renderer.dust.helpers.scriptSpecs = function (chunk) {
 		var testfolder = config.path.clientTests;
 		var jsfiles = [];
 		var scriptArr = [];
 
-		if (argv.spec) { // if a spec file was specified, only use that. will throw non-fatal error if it doesn't exist
+		if (argv.spec) { // If a spec file was specified, only use that. will throw non-fatal error if it doesn't exist
 			jsfiles = [argv.spec + '.js'];
 		} else if (fs.existsSync(testfolder)) {
-			// get all the spec files, ensure folder exists before trying to read from it, otherwise we get a noent that fails the process
-			jsfiles = fs.readdirSync(testfolder).filter(function(value) { // get only .js files
+			// Get all the spec files, ensure folder exists before trying to read from it, otherwise we get a noent that fails the process
+			jsfiles = fs.readdirSync(testfolder).filter(function (value) { // Get only .js files
 				return (path.extname(path.basename(value)) === '.js');
 			});
 		}
-		jsfiles = jsfiles.map(function(value) { // get path for asset
+		jsfiles = jsfiles.map(function (value) { // Get path for asset
 			return path.join(testfolder, value);
 		});
-		scriptArr = jsfiles.map(function(value) {
+		scriptArr = jsfiles.map(function (value) {
 			return '<script src="' + path.join('/', path.relative(config.path.root, value)) + '"></script>';
 		});
 		return chunk.write(scriptArr.join('\n'));
@@ -169,9 +166,9 @@ This script starts up a server, so you don't have to already have one running.
 		app.use('/tests', serveStatic('tests'));
 		app.use('/testslib', serveStatic(path.join(__dirname, '..', 'tests')));
 
-		app.use(function(req, res) {
+		app.use(function (req, res) {
 			if (req.url === '/') {
-				renderer.renderPartial('root__test-runner', req, res, {}, function(err, out) {
+				renderer.renderPartial('root__test-runner', req, res, {}, function (err, out) {
 					if (err) {
 						console.error('Error rendering test runner', err);
 						process.exit(1);
@@ -181,7 +178,7 @@ This script starts up a server, so you don't have to already have one running.
 					}
 				});
 			} else {
-				// may be obsolete, tbc with rest of team
+				// May be obsolete, tbc with rest of team
 				if (fs.exists(__dirname + req.url)) {
 					fs.createReadStream(__dirname + req.url).pipe(res);
 					console.log('stream');
@@ -202,7 +199,7 @@ This script starts up a server, so you don't have to already have one running.
 		var urls = [baseUri];
 
 		if (argv.browsers) {
-			return saucelabs.getActiveTunnels(function(error, tunnels) {
+			return saucelabs.getActiveTunnels(function (error, tunnels) {
 				checkError(error);
 
 				if (tunnels.length === 0) {
@@ -222,18 +219,18 @@ This script starts up a server, so you don't have to already have one running.
 			die('The `phantomjs` binary was not found in PATH.\nPlease install PhantomJS http://phantomjs.org/', 1);
 		}
 
-		var testPromises = urls.map(function(url) {
+		var testPromises = urls.map(function (url) {
 			return testPromise(url);
 		});
 		var testResults = promise.all(testPromises);
-		testResults.then(function(results) {
-			var failures = results.filter(function(value) {
+		testResults.then(function (results) {
+			var failures = results.filter(function (value) {
 				return value > 0;
 			});
 			var exitCode = 0;
 			var message = 'Finished';
 			if (failures.length) {
-				exitCode = failures[0]; // return first failure or 0
+				exitCode = failures[0]; // Return first failure or 0
 				message += ' ' + failures.length + ' failures';
 			}
 			die(message, exitCode);
@@ -292,8 +289,6 @@ This script starts up a server, so you don't have to already have one running.
 	}
 
 	function selectBrowsers(selected, candidate) {
-		// jshint maxcomplexity: 8
-
 		var name;
 		var version;
 		var competitors;
@@ -345,7 +340,7 @@ This script starts up a server, so you don't have to already have one running.
 	function concatReducedBrowsers(reducedBrowsers) {
 		var result = [];
 
-		Object.keys(reducedBrowsers).forEach(function(browser) {
+		Object.keys(reducedBrowsers).forEach(function (browser) {
 			result = result.concat(reducedBrowsers[browser]);
 		});
 
@@ -394,7 +389,7 @@ This script starts up a server, so you don't have to already have one running.
 		driver = wd.promiseRemote('ondemand.saucelabs.com', 80, saucelabsUser, saucelabsKey);
 		driver.init(browser)
 			.then(iterateTests)
-			.fail(function() {
+			.fail(function () {
 				console.log('Browser ' + sessionName + ' was not available');
 
 				// SauceLabs' shitty API returns browsers that it doesn't support.
@@ -415,7 +410,7 @@ This script starts up a server, so you don't have to already have one running.
 				next = urls.shift();
 				driver.get(next)
 					.then(runTest.bind(null, next))
-					.fail(function(error) {
+					.fail(function (error) {
 						finishTest(next, createErrorResult(error));
 					});
 			}
@@ -437,7 +432,7 @@ This script starts up a server, so you don't have to already have one running.
 			driver.waitForConditionInBrowser('!!window.mochaResults', 30000)
 				.then(driver.execute.bind(driver, 'return window.mochaResults', null))
 				.then(finishTest.bind(null, url))
-				.fail(function(error) {
+				.fail(function (error) {
 					finishTest(url, createErrorResult(error));
 				});
 		}
@@ -456,7 +451,7 @@ This script starts up a server, so you don't have to already have one running.
 				driver.quit()
 					.then(driver.sauceJobStatus.bind(driver, errors === 0))
 					.then(localDie)
-					.fail(function(error) {
+					.fail(function (error) {
 						console.error('Error: ' + error.message);
 						localDie();
 					});
@@ -467,7 +462,7 @@ This script starts up a server, so you don't have to already have one running.
 
 		function reportErrors(url, failures) {
 			if (failures) {
-				failures.forEach(function(failure) {
+				failures.forEach(function (failure) {
 					console.error('Test failed in ' + sessionName);
 					console.error('    URL: ' + url);
 					console.error('    Test: ' + failure.fullTitle);
@@ -507,10 +502,10 @@ This script starts up a server, so you don't have to already have one running.
 	function testPromise(url) {
 		var deferTest = new Deferred();
 		var mochaPhantomJsPath = require.resolve('mocha-phantomjs-core');
-		if (validUrl(url)) { // validate the string before we let it near the shell command
-			shell('phantomjs ' + mochaPhantomJsPath + ' ' + url, function(err, stdin, stderr) {
+		if (validUrl(url)) { // Validate the string before we let it near the shell command
+			shell('phantomjs ' + mochaPhantomJsPath + ' ' + url, function (err, stdin, stderr) {
 				var exitCode = (err) ? err.code : 0;
-				console.log(stdin); // always output the test results
+				console.log(stdin); // Always output the test results
 				if (stderr) {
 					console.error(stderr);
 				}
@@ -518,9 +513,8 @@ This script starts up a server, so you don't have to already have one running.
 				return deferTest.promise;
 			});
 			return deferTest;
-		} else {
-			die('Fatal error: invalid URL passed to mocha-phantomjs', 1);
 		}
+		die('Fatal error: invalid URL passed to mocha-phantomjs', 1);
 	}
 
 	/*
@@ -542,4 +536,4 @@ This script starts up a server, so you don't have to already have one running.
 		console[method](message);
 		process.exit(exitCode);
 	}
-}());
+})();

--- a/dust/amp.js
+++ b/dust/amp.js
@@ -3,7 +3,7 @@
 module.exports = initFilter;
 
 function initFilter(dust) {
-	dust.filters.amp = function(value) {
+	dust.filters.amp = function (value) {
 		return value.replace(/&(?![#a-z0-9]+?;)/g, '&amp;');
 	};
 }

--- a/dust/and.js
+++ b/dust/and.js
@@ -11,22 +11,20 @@ function initHelper(dust) {
 	 * if not is set to true
 	 * evaluates to true if none of the keys are set in the data
 	 */
-	dust.helpers.and = function(chunk, context, bodies, params) {
+	dust.helpers.and = function (chunk, context, bodies, params) {
 		params = params || {};
 		var alternate = bodies.else;
 		var keys = context.resolve(params.keys);
 		var not = context.resolve(params.not);
 
-		var checkContext = function(arr) {
-			// jshint maxcomplexity: 7
-
+		var checkContext = function (arr) {
 			var count = 0;
 			var item;
 			var nestedKeys;
 			for (var i = 0; arr[i]; ++i) {
 				nestedKeys = arr[i].split('.');
 				item = context.get(nestedKeys.shift());
-				// handle finding nested properties like foo.bar
+				// Handle finding nested properties like foo.bar
 				while (nestedKeys.length > 0 && item) {
 					item = item[nestedKeys.shift()];
 				}

--- a/dust/date-format.js
+++ b/dust/date-format.js
@@ -5,9 +5,7 @@ var dateformat = require('dateformat');
 module.exports = initHelper;
 
 function initHelper(dust, renderer, config) {
-	dust.helpers.dateFormat = function(chunk, context, bodies, params) {
-		// jshint maxcomplexity: 7
-
+	dust.helpers.dateFormat = function (chunk, context, bodies, params) {
 		var date = null;
 		var value = null;
 
@@ -17,8 +15,8 @@ function initHelper(dust, renderer, config) {
 			value = (params.date) ? context.resolve(params.date) : null;
 			date = (value) ? new Date(value.match(/^[0-9]+$/) ? parseInt(value, 10) : value) : new Date();
 			chunk.write(dateformat(date, params.format || 'yyyy-mm-dd'));
-		} catch (e) {
-			config.log.error(e.message);
+		} catch (err) {
+			config.log.error(err.message);
 		}
 		return chunk;
 	};

--- a/dust/html.js
+++ b/dust/html.js
@@ -3,14 +3,14 @@
 module.exports = initFilter;
 
 function initFilter(dust) {
-	dust.filters.html = function(value) {
+	dust.filters.html = function (value) {
 		var escapes = {
 			'<': '&#60;',
 			'>': '&#62;',
 			'"': '&#34;',
 			'\'': '&#39;'
 		};
-		return dust.filters.amp(value).replace(/[<>"']/g, function(match) {
+		return dust.filters.amp(value).replace(/[<>"']/g, function (match) {
 			return escapes[match];
 		});
 	};

--- a/dust/lower.js
+++ b/dust/lower.js
@@ -3,7 +3,7 @@
 module.exports = initFilter;
 
 function initFilter(dust) {
-	dust.filters.lower = function(value) {
+	dust.filters.lower = function (value) {
 		return value.toLowerCase();
 	};
 }

--- a/dust/number-format.js
+++ b/dust/number-format.js
@@ -3,7 +3,7 @@
 module.exports = initHelper;
 
 function initHelper(dust) {
-	dust.helpers.numberFormat = function(chunk, context, bodies, params) {
+	dust.helpers.numberFormat = function (chunk, context, bodies, params) {
 		var num = context.resolve(params.num);
 		if (num) {
 			return chunk.write(num.replace(/\B(?=(\d{3})+(?!\d))/g, ','));

--- a/dust/or.js
+++ b/dust/or.js
@@ -11,22 +11,20 @@ function initHelper(dust) {
 	 * if not is set to true
 	 * evaluates to true if at least one of the keys are missing from the data
 	 */
-	dust.helpers.or = function(chunk, context, bodies, params) {
+	dust.helpers.or = function (chunk, context, bodies, params) {
 		params = params || {};
 		var alternate = bodies.else;
 		var keys = context.resolve(params.keys);
 		var not = context.resolve(params.not);
 
-		var checkContext = function(arr) {
-			// jshint maxcomplexity: 7
-
+		var checkContext = function (arr) {
 			var count = 0;
 			var item;
 			var nestedKeys;
 			for (var i = 0; arr[i]; ++i) {
 				nestedKeys = arr[i].split('.');
 				item = context.get(nestedKeys.shift());
-				// handle finding nested properties like foo.bar
+				// Handle finding nested properties like foo.bar
 				while (nestedKeys.length > 0 && item) {
 					item = item[nestedKeys.shift()];
 				}

--- a/dust/strip-tags.js
+++ b/dust/strip-tags.js
@@ -3,7 +3,7 @@
 module.exports = initFilter;
 
 function initFilter(dust) {
-	dust.filters.stripTags = function(value) {
+	dust.filters.stripTags = function (value) {
 		return value.replace(/<[^>]+>/g, '');
 	};
 	dust.filters.strip = dust.filters.stripTags;

--- a/dust/title.js
+++ b/dust/title.js
@@ -3,8 +3,8 @@
 module.exports = initFilter;
 
 function initFilter(dust) {
-	dust.filters.title = function(value) {
-		return value.replace(/\w+/g, function(txt) {
+	dust.filters.title = function (value) {
+		return value.replace(/\w+/g, function (txt) {
 			return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
 		});
 	};

--- a/dust/trim.js
+++ b/dust/trim.js
@@ -3,7 +3,7 @@
 module.exports = initFilter;
 
 function initFilter(dust) {
-	dust.filters.trim = function(value) {
+	dust.filters.trim = function (value) {
 		return value.toString().trim();
 	};
 }

--- a/dust/upper.js
+++ b/dust/upper.js
@@ -3,7 +3,7 @@
 module.exports = initFilter;
 
 function initFilter(dust) {
-	dust.filters.upper = function(value) {
+	dust.filters.upper = function (value) {
 		return value.toUpperCase();
 	};
 }

--- a/filters/input/environment.js
+++ b/filters/input/environment.js
@@ -2,15 +2,13 @@
 
 var qs = require('qs');
 
-module.exports = function(config, req, res, data, next) {
-	// jscs:disable requireCamelCaseOrUpperCaseIdentifiers
-
-	var cast = function(params) {
+module.exports = function (config, req, res, data, next) {
+	var cast = function (params) {
 		var output = {};
 
 		params = params || {};
 
-		var transform = function(value) {
+		var transform = function (value) {
 			var val = (typeof value === 'string') ? value.toLowerCase() : value;
 			if (val === 'true' || val === 'false') {
 				return val === 'true';
@@ -21,7 +19,7 @@ module.exports = function(config, req, res, data, next) {
 			return value;
 		};
 
-		Object.keys(params).forEach(function(key) {
+		Object.keys(params).forEach(function (key) {
 			if (Array.isArray(params[key])) {
 				output[key] = params[key].map(transform);
 			} else {
@@ -31,8 +29,11 @@ module.exports = function(config, req, res, data, next) {
 		return output;
 	};
 
+	/* eslint-disable camelcase */
 	data.query_data = cast(req.query);
 	data.query_string = qs.stringify(data.query_data);
 	data.request_url = (req.url) ? req.url.replace(/\?.*$/, '') : '';
+	/* eslint-enable camelcase */
+
 	next(data);
 };

--- a/lib/benchmark.js
+++ b/lib/benchmark.js
@@ -1,14 +1,14 @@
 
 'use strict';
 
-module.exports = function(config) {
+module.exports = function (config) {
 	var statsd = require('./statsd')(config);
 
-	return function(req, res, next) {
+	return function (req, res, next) {
 		var timer = config.timer();
 		var end = res.end;
 
-		res.end = function() {
+		res.end = function () {
 			statsd.classifiedTiming(req.url, 'response_time', timer('Request completed ' + req.url));
 			end.apply(res, Array.prototype.slice.call(arguments, 0));
 		};

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,9 +1,7 @@
 
 'use strict';
 
-module.exports = function(env, config, args) {
-	// jshint maxcomplexity: 9
-
+module.exports = function (env, config, args) {
 	config = config || {};
 
 	env = env || process.env.NODE_ENV || 'development';
@@ -89,20 +87,20 @@ module.exports = function(env, config, args) {
 		.alias('h', 'help')
 		.help()
 		.alias('v', 'version')
-		.version(function() {
+		.version(function () {
 			return require('../package').version;
 		})
-		.check(function(argv, args) {
+		.check(function (argv, args) {
 			var exclude = ['_', '$0'];
 
-			Object.keys(argv).forEach(function(key) {
+			Object.keys(argv).forEach(function (key) {
 				if (exclude.indexOf(key) === -1 && !args.hasOwnProperty(key)) {
 					throw new Error('Unknown argument error: `' + key + '` is not a valid argument');
 				}
 			});
-			Object.keys(args).forEach(function(key) {
+			Object.keys(args).forEach(function (key) {
 				if (Array.isArray(argv[key])) {
-					throw new Error('Invalid argument error: `' + key + '` must only be specified once');
+					throw new TypeError('Invalid argument error: `' + key + '` must only be specified once');
 				}
 			});
 			return true;
@@ -114,13 +112,13 @@ module.exports = function(env, config, args) {
 	var defaultConfig = {
 		argv: args,
 		env: {
-			host: function() {
+			host: function () {
 				return hostname;
 			},
-			isDevelopment: function() {
+			isDevelopment: function () {
 				return this.name === 'development';
 			},
-			isProduction: function() {
+			isProduction: function () {
 				return this.name === 'production';
 			},
 			name: env
@@ -171,9 +169,9 @@ module.exports = function(env, config, args) {
 			templates: 'view',
 			tests: 'tests'
 		},
-		timer: function() {
+		timer: function () {
 			var start = Date.now();
-			return function(msg) {
+			return function (msg) {
 				var diff = Date.now() - start;
 				config.log.debug(msg + ' - ' + diff + 'ms');
 				return diff;
@@ -193,11 +191,13 @@ module.exports = function(env, config, args) {
 		extend(true, config, require(localConfig));
 	}
 	if (config.argv.syslog && config.syslogAppName) {
-		// jscs:disable requireCamelCaseOrUpperCaseIdentifiers
+		/* eslint import/no-unassigned-import:warn */
 		require('winston-syslog');
 		config.log.add(winston.transports.Syslog, {
 			localhost: hostname,
+			/* eslint-disable camelcase */
 			app_name: config.syslogAppName,
+			/* eslint-enable camelcase */
 			level: 'debug'
 		});
 	}

--- a/lib/content-type.js
+++ b/lib/content-type.js
@@ -1,10 +1,10 @@
 
 'use strict';
 
-module.exports = function(url, opts) {
+module.exports = function (url, opts) {
 	opts = opts || {};
 
-	var ext = (url.indexOf('.') !== -1) ? url.split('.').pop().replace(/\?.*/, '') : null;
+	var ext = (url.indexOf('.') === -1) ? null : url.split('.').pop().replace(/\?.*/, '');
 
 	var mapping = {
 		atom: 'application/atom+xml',

--- a/lib/dispatch.js
+++ b/lib/dispatch.js
@@ -1,24 +1,24 @@
 
 'use strict';
 
-module.exports = function(config) {
+module.exports = function (config) {
 	var statsd = require('./statsd')(config);
 	var outputFilter = require('./output-filter')(config);
 	var contentType = require('./content-type');
 	var http = require('http');
 
 	var api = {
-		send: function(err, out, req, res, status) {
+		send: function (err, out, req, res, status) {
 			var timer = config.timer();
 			var mimeType;
 
-			var getErrorContent = function(err, req, res) {
-				require('./error-pages')(config).getPage(err, req, res, function(content) {
+			var getErrorContent = function (err, req, res) {
+				require('./error-pages')(config).getPage(err, req, res, function (content) {
 					doSend(content || api.error(err, status));
 				});
 			};
 
-			var doSend = function(content) {
+			var doSend = function (content) {
 				var length = Buffer.byteLength(content);
 				if (!mimeType) {
 					mimeType = contentType(req.url, {charset: 'utf-8'});
@@ -47,7 +47,7 @@ module.exports = function(config) {
 				doSend(outputFilter(out, contentType(req.url), req));
 			}
 		},
-		error: function(err, status) {
+		error: function (err, status) {
 			var message = (err.message || err.toString());
 
 			var statusMessage = http.STATUS_CODES[status] || 'Internal server error';
@@ -56,7 +56,7 @@ module.exports = function(config) {
 				'</head>',
 				'<body><div style="font-family: sans-serif; color: gray; font-size: 20px; font-weight: bold; margin-top: 200px; text-align: center;">' + status + ' &ndash; ' + statusMessage + '</div>',
 				'\n<!--\n\n',
-				function() {/*
+				function () {/*
 					   ___    _                        _
 					  / __|  | |_     _  _    _ _     | |_     ___      _ _
 					  \__ \  | ' \   | +| |  | ' \    |  _|   / -_)    | '_|

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -1,13 +1,13 @@
 
 'use strict';
 
-module.exports = function(dust, renderer, config) {
+module.exports = function (dust, renderer, config) {
 	var compileOnDemandCache = {};
 
-	// override dust load mechanism to support namespaced templates
+	// Override dust load mechanism to support namespaced templates
 	// and to not blow up if the template is not found
-	dust.onLoad = function(name, options, callback) {
-		var getTemplate = function(namespace) {
+	dust.onLoad = function (name, options, callback) {
+		var getTemplate = function (namespace) {
 			if (!namespace.length) {
 				return dust.cache[name];
 			}
@@ -32,7 +32,7 @@ module.exports = function(dust, renderer, config) {
 		}
 	};
 
-	dust.helpers.assetPath = function(chunk, context, bodies, params) {
+	dust.helpers.assetPath = function (chunk, context, bodies, params) {
 		var path = renderer.assetPath(context.resolve(params.src));
 		if (!path) {
 			return chunk;

--- a/lib/error-pages.js
+++ b/lib/error-pages.js
@@ -11,11 +11,11 @@
 			...whatever data you require to render your page...
 */
 
-module.exports = function(config) {
+module.exports = function (config) {
 	var renderer = require('./renderer')(config);
 
-	var renderPageForContext = function(req, res, templateContext, fn) {
-		renderer.render(req, res, templateContext, function(err, out) {
+	var renderPageForContext = function (req, res, templateContext, fn) {
+		renderer.render(req, res, templateContext, function (err, out) {
 			if (err || !out) {
 				config.log.warn('Rendering custom error page failed (misconfiguration?)');
 				fn(null);
@@ -25,7 +25,7 @@ module.exports = function(config) {
 		});
 	};
 
-	var getTemplateContext = function(err, req) {
+	var getTemplateContext = function (err, req) {
 		var key = typeof err.status === 'string' ? err.status : err.status.toString();
 		var userData = config.errorPages;
 		var layout = userData.errorLayouts.hasOwnProperty(key) ? userData.errorLayouts[key] : userData.errorLayouts.default;
@@ -47,7 +47,7 @@ module.exports = function(config) {
 
 		if (userData.staticData) {
 			for (var key in userData.staticData) {
-				// prevent the user clobbering required templateContext keys & proto
+				// Prevent the user clobbering required templateContext keys & proto
 				if (userData.staticData.hasOwnProperty(key) && !(key in templateContext)) {
 					templateContext[key] = userData.staticData[key];
 				}
@@ -58,7 +58,7 @@ module.exports = function(config) {
 	};
 
 	return {
-		getPage: function(err, req, res, fn) {
+		getPage: function (err, req, res, fn) {
 			if (!config.errorPages || !config.errorPages.errorLayouts || !config.errorPages.errorLayouts.default) {
 				fn(null);
 			} else {
@@ -66,5 +66,4 @@ module.exports = function(config) {
 			}
 		}
 	};
-
 };

--- a/lib/input-filter.js
+++ b/lib/input-filter.js
@@ -1,11 +1,11 @@
 
 'use strict';
 
-module.exports = function(config) {
+module.exports = function (config) {
 	return {
 		filters: [],
 
-		getBase: function(data, key) {
+		getBase: function (data, key) {
 			if (data && data.article && data.article[key]) {
 				return data.article;
 			}
@@ -15,25 +15,23 @@ module.exports = function(config) {
 			return null;
 		},
 
-		add: function(filter) {
+		add: function (filter) {
 			this.filters.push(filter);
 		},
 
-		run: function(req, res, data, callback) {
+		run: function (req, res, data, callback) {
 			var self = this;
 
-			var runner = function(filters, data) {
+			var runner = function (filters, data) {
 				var remain;
 				var filter;
 				var arity;
 				var cb;
 
-				if (!filters.length) {
-					callback(data);
-				} else {
+				if (filters.length) {
 					filter = filters[0];
 					remain = filters.slice(1);
-					cb = function(data) {
+					cb = function (data) {
 						runner(remain, data);
 					};
 					arity = filter.length;
@@ -50,6 +48,8 @@ module.exports = function(config) {
 						config.log.error('Input filters must accept 1, 2, 3 or 5 arguments ' + arity + ' found');
 						runner(remain, data);
 					}
+				} else {
+					callback(data);
 				}
 			};
 			runner(this.filters, data);

--- a/lib/map-route.js
+++ b/lib/map-route.js
@@ -1,10 +1,10 @@
 
 'use strict';
 
-module.exports = function(address) {
+module.exports = function (address) {
 	var url = require('url');
 
-	var parseUrl = function(address) {
+	var parseUrl = function (address) {
 		var protocol = url.parse(address).protocol || null;
 
 		if (protocol === 'http:' || protocol === 'https:') {
@@ -14,7 +14,7 @@ module.exports = function(address) {
 		return url.parse('http://' + address);
 	};
 
-	var map = function(address) {
+	var map = function (address) {
 		var mappedRoute = {};
 		var route = parseUrl(address);
 

--- a/lib/output-filter.js
+++ b/lib/output-filter.js
@@ -4,23 +4,23 @@
 var path = require('path');
 var eachModule = require('each-module');
 
-module.exports = function(config) {
+module.exports = function (config) {
 	var filters = [];
 
-	var modulePaths = config.modules.map(function(module) {
+	var modulePaths = config.modules.map(function (module) {
 		return path.join(config.path.root, 'node_modules', module);
 	});
 	modulePaths.push(config.path.root);
 	modulePaths.unshift(config.path.shunterRoot);
 
-	modulePaths.forEach(function(modulePath) {
+	modulePaths.forEach(function (modulePath) {
 		var filterPath = path.join(modulePath, config.structure.filters, config.structure.filtersOutput);
-		eachModule(filterPath, function(name, runFilter) {
+		eachModule(filterPath, function (name, runFilter) {
 			filters.push(runFilter);
 		});
 	});
 
-	return function(content, contentType, req) {
+	return function (content, contentType, req) {
 		var output;
 
 		for (var i = 0; filters[i]; ++i) {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,8 +1,8 @@
 
 'use strict';
 
-// middlewares
-module.exports = function(config, renderer) {
+// Middlewares
+module.exports = function (config, renderer) {
 	var pkg = require('../package.json');
 	var httpProxy = require('http-proxy');
 	var rewriteRedirect = config.argv['rewrite-redirect'] || false;
@@ -17,7 +17,7 @@ module.exports = function(config, renderer) {
 	var router = require('./router')(config);
 
 	var proxyErr = false;
-	proxy.on('proxyRes', function(proxyRes) {
+	proxy.on('proxyRes', function (proxyRes) {
 		if (proxyRes.statusCode >= 400) {
 			proxyErr = new Error(proxyRes.statusMessage);
 			proxyErr.status = proxyRes.statusCode;
@@ -26,7 +26,7 @@ module.exports = function(config, renderer) {
 		}
 	});
 
-	var parseJson = function(data) {
+	var parseJson = function (data) {
 		var json = null;
 		var err = null;
 
@@ -43,22 +43,21 @@ module.exports = function(config, renderer) {
 	};
 
 	var processor = {
-		timestamp: function(req, res, next) {
+		timestamp: function (req, res, next) {
 			req.headers['X-Shunter-Deploy-Timestamp'] = deployTimestamp;
 			next();
 		},
 
-		shunterVersion: function(req, res, next) {
+		shunterVersion: function (req, res, next) {
 			req.headers['X-Shunter'] = pkg.version;
 			next();
 		},
 
-		intercept: function(req, res, next) {
-			// jscs:disable disallowDanglingUnderscores
+		intercept: function (req, res, next) {
 			var data = [];
 			var status = null;
 
-			var shouldIntercept = function() {
+			var shouldIntercept = function () {
 				var type = res.getHeader('Content-type');
 				var method = req.method ? req.method.toUpperCase() : 'GET';
 				var acceptedType = type && (type.indexOf('x-shunter+json') !== -1);
@@ -67,7 +66,7 @@ module.exports = function(config, renderer) {
 				return acceptedType && acceptedMethod;
 			};
 
-			var writeHead = function(code) {
+			var writeHead = function (code) {
 				statsd.increment('total_requests');
 
 				if (shouldIntercept()) {
@@ -86,18 +85,18 @@ module.exports = function(config, renderer) {
 				}
 			};
 
-			var write = function(chunk) {
+			var write = function (chunk) {
 				data.push(chunk);
 			};
 
-			var endProxyError = function() {
+			var endProxyError = function () {
 				res.writeHead = res.__originalWriteHead;
 				res.write = res.__originalWrite;
 				res.end = res.__originalEnd;
 				return dispatch.send(proxyErr, '', req, res);
 			};
 
-			var endIntercept = function() {
+			var endIntercept = function () {
 				var timer = config.timer();
 
 				if (req.__proxyTimingFunctionBodyReceived) {
@@ -113,7 +112,9 @@ module.exports = function(config, renderer) {
 				res.write = res.__originalWrite;
 				res.end = res.__originalEnd;
 
-				if (!json.error) {
+				if (json.error) {
+					dispatch.send(json.error, '', req, res);
+				} else {
 					if (config.jsonViewParameter && req.query[config.jsonViewParameter]) {
 						req.isJson = true;
 						var jsonOutput = JSON.stringify(json.data, null, '\t');
@@ -121,12 +122,10 @@ module.exports = function(config, renderer) {
 					}
 
 					var timer = config.timer();
-					renderer.render(req, res, json.data, function(err, out) {
+					renderer.render(req, res, json.data, function (err, out) {
 						statsd.classifiedTiming(req.url, 'rendering', timer('Rendering ' + req.url));
 						dispatch.send(err, out, req, res, status);
 					});
-				} else {
-					dispatch.send(json.error, '', req, res);
 				}
 			};
 
@@ -137,15 +136,14 @@ module.exports = function(config, renderer) {
 			res.writeHead = writeHead;
 
 			next();
-			// jscs:enable disallowDanglingUnderscores
 		},
 
-		ping: function(req, res) {
+		ping: function (req, res) {
 			res.writeHead(200);
 			res.end('pong');
 		},
 
-		api: function(req, res) {
+		api: function (req, res) {
 			var name = req.url.replace(/^\/+/, '').replace(/\?.*/, '').replace(/\/+/g, '__');
 			var body = req.body;
 			var err = null;
@@ -155,7 +153,7 @@ module.exports = function(config, renderer) {
 			}
 
 			if (name) {
-				renderer.renderPartial(name, req, res, body, function(err, out) {
+				renderer.renderPartial(name, req, res, body, function (err, out) {
 					dispatch.send(err, out, req, res);
 				});
 			} else {
@@ -165,42 +163,42 @@ module.exports = function(config, renderer) {
 			}
 		},
 
-		proxy: function(req, res) {
-			// jscs:disable disallowDanglingUnderscores
+		proxy: function (req, res) {
 			req.headers = req.headers || {};
 
 			var host = req.headers.host || '';
 			var route = router.map(host, req.url);
 			var err = null;
 
-			var rewriteRequestHeaders = function() {
+			var rewriteRequestHeaders = function () {
 				if (route.changeOrigin) {
 					req.headers['X-Orig-Host'] = host;
 				}
 			};
 
-			if (!route) {
+			if (route) {
+				if (route.host) {
+					route.target = 'http://' + route.host + (route.port ? ':' + route.port : '');
+
+					config.log.info('Proxying request for ' + host + req.url + ' to ' + route.target + req.url);
+					req.__proxyTimingFunctionHeadersReceived = config.timer();
+					req.__proxyTimingFunctionBodyReceived = config.timer();
+
+					rewriteRequestHeaders();
+					proxy.web(req, res, route, function (err) {
+						err.status = (err.code === 'ECONNREFUSED') ? 502 : 500;
+						dispatch.send(err, null, req, res);
+					});
+				} else {
+					err = new Error('Route does not define a host');
+					err.status = 500;
+					dispatch.send(err, null, req, res);
+				}
+			} else {
 				err = new Error('Request did not match any route');
 				err.status = 404;
 				dispatch.send(err, null, req, res);
-			} else if (!route.host) {
-				err = new Error('Route does not define a host');
-				err.status = 500;
-				dispatch.send(err, null, req, res);
-			} else {
-				route.target = 'http://' + route.host + (route.port ? ':' + route.port : '');
-
-				config.log.info('Proxying request for ' + host + req.url + ' to ' + route.target + req.url);
-				req.__proxyTimingFunctionHeadersReceived = config.timer();
-				req.__proxyTimingFunctionBodyReceived = config.timer();
-
-				rewriteRequestHeaders();
-				proxy.web(req, res, route, function(err) {
-					err.status = (err.code === 'ECONNREFUSED') ? 502 : 500;
-					dispatch.send(err, null, req, res);
-				});
 			}
-			// jscs:enable disallowDanglingUnderscores
 		}
 	};
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function(config) {
+module.exports = function (config) {
 	var dust = require('dustjs-helpers');
 	var mincer = require('mincer');
 	var fs = require('fs');
@@ -10,34 +10,34 @@ module.exports = function(config) {
 	var eachModule = require('each-module');
 
 	var hostAppDir = config.path.root;
-	var modulesPaths = config.modules.map(function(module) {
+	var modulesPaths = config.modules.map(function (module) {
 		return path.join(hostAppDir, 'node_modules', module);
 	});
 
 	mincer.logger.use(config.log);
 
-	var initExtensions = function() {
+	var initExtensions = function () {
 		var paths = [].slice.call(arguments, 0, -1);
 		var callback = arguments[arguments.length - 1];
 		var locations = [config.path.shunterRoot].concat(modulesPaths, hostAppDir);
 
 		if (typeof callback === 'function') {
-			locations.forEach(function(dir) {
+			locations.forEach(function (dir) {
 				var extensionPath = path.join.apply(path, [dir].concat(paths));
 				eachModule(extensionPath, callback);
 			});
 		}
 	};
 
-	// load input filters from host app and modules
-	initExtensions(config.structure.filters, config.structure.filtersInput, function(name, inputFilter) {
+	// Load input filters from host app and modules
+	initExtensions(config.structure.filters, config.structure.filtersInput, function (name, inputFilter) {
 		if (typeof inputFilter === 'function') {
 			inputFilters.add(inputFilter);
 		}
 	});
 
-	// load mincer extensions from the host app and modules
-	initExtensions(config.structure.mincer, function(name, initMincerExtension) {
+	// Load mincer extensions from the host app and modules
+	initExtensions(config.structure.mincer, function (name, initMincerExtension) {
 		if (typeof initMincerExtension === 'function') {
 			initMincerExtension(mincer, config);
 		}
@@ -45,9 +45,9 @@ module.exports = function(config) {
 
 	var environment = new mincer.Environment();
 	var manifest = new mincer.Manifest(environment, config.path.publicResources);
-	// host app can be shunter-based app or manifest, so rely on root
+	// Host app can be shunter-based app or manifest, so rely on root
 
-	var assetPath = function(name) {
+	var assetPath = function (name) {
 		var isProduction = config.env.isProduction();
 		var asset = (isProduction) ? manifest.assets[name] : environment.findAsset(name);
 		if (!asset) {
@@ -67,12 +67,12 @@ module.exports = function(config) {
 	var themeResourcesPath = config.path.resources;
 	// NB: risk of mincer clashes until stuff is moved out of proxy
 	// for each asset type, add host then module. this order is important
-	assetTypes.forEach(function(assetType) {
+	assetTypes.forEach(function (assetType) {
 		var newPath = path.join(themeResourcesPath, assetType);
 		if (fs.existsSync(newPath)) {
 			environment.appendPath(newPath);
 		}
-		modulesPaths.reverse().forEach(function(modulePath) {
+		modulesPaths.reverse().forEach(function (modulePath) {
 			var newPath = path.join(modulePath, 'resources', assetType);
 			if (fs.existsSync(newPath)) {
 				environment.appendPath(newPath);
@@ -80,13 +80,12 @@ module.exports = function(config) {
 		});
 	});
 
-	// load ejs helpers from the host app and modules
-	initExtensions(config.structure.ejs, function(name, initEjsHelper) {
+	// Load ejs helpers from the host app and modules
+	initExtensions(config.structure.ejs, function (name, initEjsHelper) {
 		if (typeof initEjsHelper === 'function') {
 			initEjsHelper(environment, manifest, config);
 		}
 	});
-
 
 	return {
 		TEMPLATE_CACHE_KEY_PREFIX: 'root',
@@ -96,20 +95,20 @@ module.exports = function(config) {
 		manifest: manifest,
 		assetPath: assetPath,
 
-		assetServer: function() {
+		assetServer: function () {
 			return mincer.createServer(environment);
 		},
 
-		initDustExtensions: function() {
+		initDustExtensions: function () {
 			require('./dust')(dust, this, config);
-			initExtensions(config.structure.dust, function(name, initDustExtension) {
+			initExtensions(config.structure.dust, function (name, initDustExtension) {
 				if (typeof initDustExtension === 'function') {
 					initDustExtension(dust, this, config);
 				}
 			}.bind(this));
 		},
 
-		compileFile: function(fp) {
+		compileFile: function (fp) {
 			var ext = config.structure.templateExt;
 			var id;
 			var compiled;
@@ -123,59 +122,59 @@ module.exports = function(config) {
 				sandboxNS = sandboxNS.substring(sandboxNS.indexOf('view'));
 				splitPath = sandboxNS.split(path.sep);
 				if (splitPath.indexOf(config.structure.templates) > -1) {
-					// remove internal structure path
+					// Remove internal structure path
 					splitPath.splice(splitPath.indexOf(config.structure.templates), 1);
 				}
-				// reset to basename
+				// Reset to basename
 				splitPath[splitPath.length - 1] = path.basename(fp, ext);
 				splitPath.unshift(this.TEMPLATE_CACHE_KEY_PREFIX);
-				// build id from path parts
+				// Build id from path parts
 				id = splitPath.join('__');
 
 				timer = config.timer();
 				try {
 					compiled = dust.compile(fs.readFileSync(fp, 'utf8'), id);
 					dust.loadSource(compiled);
-				} catch (e) {
-					config.log.error('Compilation error: ' + e.message + ' in ' + fp);
+				} catch (err) {
+					config.log.error('Compilation error: ' + err.message + ' in ' + fp);
 				}
 				timer('Compiling ' + fp + ' as ' + id);
 			}
 		},
 
 		// Just used for testing?
-		compilePaths: function(paths) {
+		compilePaths: function (paths) {
 			var self = this;
 			if (typeof paths === 'string') {
 				paths = [].slice.call(arguments, 0);
 			}
-			paths.forEach(function(name) {
+			paths.forEach(function (name) {
 				// DEPRECATED: checking both themes and templates folders for the right template file
 				// when updated, should just look for 'self.compileFile(name));'
 				// name will need to be full path, or contain the relevant subfolders e.g. laserwolf/views/subject/foo.dust
 
 				if (fs.existsSync(path.join(config.path.themes, name))) {
-					// themes
+					// Themes
 					self.compileFile(path.join(config.path.themes, name));
 				} else if (fs.existsSync(path.join(config.path.templates, name))) {
-					// old shunter-proxy
+					// Old shunter-proxy
 					self.compileFile(path.join(config.path.templates, name));
 				} else if (fs.existsSync(name)) {
-					// full path
+					// Full path
 					self.compileFile(name);
 				} else {
 					config.log.info('Could not find template ' + name);
 				}
-				// end DEPRECATED
+				// End DEPRECATED
 			});
 		},
 
-		compileTemplates: function(forTests) {
+		compileTemplates: function (forTests) {
 			var fullFiles = [];
 			// Get all defined modules templates first (in order defined by the host app)
-			config.modules.forEach(function(module) {
+			config.modules.forEach(function (module) {
 				var moduleResourcesPath = (forTests) ? forTests : path.join(hostAppDir, 'node_modules', module);
-				// must use / for glob even with windows
+				// Must use / for glob even with windows
 				var templates = [moduleResourcesPath, config.structure.templates, '**', ('*' + config.structure.templateExt)].join('/');
 				fullFiles = fullFiles.concat(glob.sync(templates, {}));
 			});
@@ -186,39 +185,39 @@ module.exports = function(config) {
 			this.compileFileList(fullFiles);
 		},
 
-		compileOnDemand: function(name) {
+		compileOnDemand: function (name) {
 			var self = this;
 			var localPath = path.join(config.structure.templates, name.split('__').join(path.sep) + config.structure.templateExt);
-			config.modules.map(function(module) {
+			config.modules.map(function (module) {
 				return path.join(hostAppDir, 'node_modules', module, localPath);
 			}).concat([
 				path.join(config.path.themes, localPath)
-			]).filter(function(file) {
+			]).filter(function (file) {
 				return fs.existsSync(file);
-			}).forEach(function(file) {
+			}).forEach(function (file) {
 				self.compileFile(file);
 			});
 		},
 
-		// accepts an array of files with full paths, sends each to compile
-		compileFileList: function(fileArr) {
+		// Accepts an array of files with full paths, sends each to compile
+		compileFileList: function (fileArr) {
 			var self = this;
-			fileArr.forEach(function(file) {
+			fileArr.forEach(function (file) {
 				self.compileFile(file);
 			});
 		},
 
-		watchTemplates: function() {
+		watchTemplates: function () {
 			var watchTree;
 			var watcher;
 			var folders = [config.path.templates];
 			var self = this;
 
-			var compile = function(fp) {
+			var compile = function (fp) {
 				self.compileFile(fp);
 			};
 
-			modulesPaths.forEach(function(mp) {
+			modulesPaths.forEach(function (mp) {
 				folders.push(path.join(mp, config.structure.templates));
 			});
 			watchTree = require('./watcher')(config.structure.templateExt).watchTree;
@@ -228,19 +227,19 @@ module.exports = function(config) {
 			config.log.debug('Watching ' + folders.join(', ') + ' for changes');
 		},
 
-		watchDustExtensions: function() {
+		watchDustExtensions: function () {
 			var watchTree;
 			var watcher;
 			var folders = [config.path.dust];
 			var self = this;
 
-			var compile = function(fp) {
+			var compile = function (fp) {
 				config.log.info('Loading Dust extension ' + fp);
 				delete require.cache[require.resolve(fp)];
 				require(fp)(dust, self, config);
 			};
 
-			modulesPaths.forEach(function(mp) {
+			modulesPaths.forEach(function (mp) {
 				folders.push(path.join(mp, config.structure.dust));
 			});
 			watchTree = require('./watcher')('.js').watchTree;
@@ -250,20 +249,20 @@ module.exports = function(config) {
 			config.log.debug('Watching ' + folders.join(', ') + ' for changes');
 		},
 
-		render: function(req, res, data, callback) {
+		render: function (req, res, data, callback) {
 			var name = (data && data.layout && data.layout.template) ? data.layout.template : 'layout';
 			this.renderPartial(name, req, res, data, callback);
 		},
 
-		renderPartial: function(partial, req, res, data, callback) {
-			inputFilters.run(req, res, data, function(data) {
+		renderPartial: function (partial, req, res, data, callback) {
+			inputFilters.run(req, res, data, function (data) {
 				var ns = (data && data.layout && data.layout.namespace) ? data.layout.namespace : null;
 				var base = dust.makeBase({
 					namespace: ns
 				}, {
 					namespace: ns
 				});
-				dust.render(partial, base.push(data), function(err, out) {
+				dust.render(partial, base.push(data), function (err, out) {
 					callback(err, out);
 				});
 			});

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,7 +1,7 @@
 
 'use strict';
 
-module.exports = function(config) {
+module.exports = function (config) {
 	var extend = require('extend');
 	var mapRoute = require('./map-route');
 	var routes = config.routes;
@@ -22,7 +22,7 @@ module.exports = function(config) {
 		}
 	}
 
-	var matchRoute = function(pattern, url) {
+	var matchRoute = function (pattern, url) {
 		if (pattern.match(/^\/.+?\/$/)) {
 			return url.match(new RegExp(pattern.replace(/^\//, '').replace(/\/$/, ''), 'i'));
 		}
@@ -30,7 +30,7 @@ module.exports = function(config) {
 	};
 
 	return {
-		map: function(domain, url) {
+		map: function (domain, url) {
 			domain = domain.replace(/:[0-9]+$/, '');
 			if (!routes.hasOwnProperty(domain)) {
 				domain = 'localhost';

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,7 +1,7 @@
 
 'use strict';
 
-module.exports = function(config) {
+module.exports = function (config) {
 	var cluster = require('cluster');
 	var fs = require('fs');
 	var path = require('path');
@@ -9,8 +9,8 @@ module.exports = function(config) {
 
 	var SHUTDOWN_TIMEOUT = 10000;
 
-	var init = function(count, callback) {
-		cluster.on('exit', function(worker, code) {
+	var init = function (count, callback) {
+		cluster.on('exit', function (worker, code) {
 			if (code !== 0) {
 				config.log.error(worker.process.pid + ' died with error code ' + code + ', starting new worker...');
 				cluster.fork();
@@ -18,7 +18,7 @@ module.exports = function(config) {
 		});
 
 		var ready = 0;
-		var listening = function() {
+		var listening = function () {
 			if (++ready === count) {
 				callback();
 			}
@@ -29,8 +29,8 @@ module.exports = function(config) {
 		}
 	};
 
-	var restart = function() {
-		var replace = function(workers) {
+	var restart = function () {
+		var replace = function (workers) {
 			if (!workers.length) {
 				config.log.info('All replacement workers now running');
 				return;
@@ -41,17 +41,17 @@ module.exports = function(config) {
 			var pid = parasite.process.pid;
 			var timeout;
 
-			parasite.on('disconnect', function() {
+			parasite.on('disconnect', function () {
 				config.log.info('Shutdown complete for ' + pid);
 				clearTimeout(timeout);
 			});
 			parasite.disconnect();
-			timeout = setTimeout(function() {
+			timeout = setTimeout(function () {
 				config.log.info('Timed out waiting for ' + pid + ' to disconnect, killing process');
 				parasite.send('force exit');
 			}, SHUTDOWN_TIMEOUT);
 
-			worker.on('listening', function() {
+			worker.on('listening', function () {
 				config.log.info('Created process ' + worker.process.pid + ' to replace ' + pid);
 				replace(workers.slice(1));
 			});
@@ -60,9 +60,9 @@ module.exports = function(config) {
 		replace(Object.keys(cluster.workers));
 	};
 
-	var saveProcessId = function() {
+	var saveProcessId = function () {
 		var pid = process.pid;
-		fs.writeFile(path.join(config.path.root, 'shunter.pid'), pid, function(err) {
+		fs.writeFile(path.join(config.path.root, 'shunter.pid'), pid, function (err) {
 			if (err) {
 				config.log.error('Error saving shunter.pid file for process ' + pid + ' ' + (err.message || err.toString()));
 			} else {
@@ -71,20 +71,20 @@ module.exports = function(config) {
 		});
 	};
 
-	var clearProcessId = function() {
+	var clearProcessId = function () {
 		config.log.debug('Deleting old shunter.pid file');
 		fs.unlinkSync(path.join(config.path.root, 'shunter.pid'));
 	};
 
-	var saveTimestamp = function() {
+	var saveTimestamp = function () {
 		fs.writeFileSync(path.join(config.path.shunterRoot, 'timestamp.json'), '{"value":' + Date.now() + '}');
 	};
 
 	return {
-		use: function() {
+		use: function () {
 			config.middleware.push(Array.prototype.slice.call(arguments));
 		},
-		start: function() {
+		start: function () {
 			if (cluster.isMaster) {
 				var childProcesses = Math.min(
 					require('os').cpus().length,
@@ -93,20 +93,20 @@ module.exports = function(config) {
 				saveTimestamp();
 				saveProcessId();
 
-				init(childProcesses, function() {
+				init(childProcesses, function () {
 					config.log.info('Shunter started with ' + childProcesses + ' child processes listening');
 				});
 
-				process.on('SIGUSR2', function() {
+				process.on('SIGUSR2', function () {
 					config.log.debug('SIGUSR2 received, reloading all workers');
 					saveTimestamp();
 					restart();
 				});
-				process.on('SIGINT', function() {
+				process.on('SIGINT', function () {
 					config.log.debug('SIGINT received, exiting...');
 					process.exit(0);
 				});
-				process.on('exit', function() {
+				process.on('exit', function () {
 					clearProcessId();
 					config.log.info('Goodbye!');
 				});

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -1,11 +1,11 @@
 
 'use strict';
 
-module.exports = function(config) {
+module.exports = function (config) {
 	var SDC = require('statsd-client');
 	var client = new SDC(config.statsd);
 
-	var mappings = (config.statsd && config.statsd.mappings ? config.statsd.mappings : []).map(function(item) {
+	var mappings = (config.statsd && config.statsd.mappings ? config.statsd.mappings : []).map(function (item) {
 		if (item.pattern && typeof item.pattern === 'string') {
 			item.pattern = new RegExp(item.pattern);
 		}
@@ -23,7 +23,7 @@ module.exports = function(config) {
 	];
 
 	var obj = {
-		buildMetricNameForUrl: function(url, name) {
+		buildMetricNameForUrl: function (url, name) {
 			if (!mappings.length) {
 				return name;
 			}
@@ -37,14 +37,14 @@ module.exports = function(config) {
 	};
 	var slice = Array.prototype.slice;
 
-	var noop = function() { };
+	var noop = function () { };
 	var mock = config && config.statsd ? config.statsd.mock : true;
 
-	methods.forEach(function(method) {
+	methods.forEach(function (method) {
 		var prefixedMethod = 'classified' + method.charAt(0).toUpperCase() + method.substring(1);
 
 		obj[method] = (mock) ? noop : client[method].bind(client);
-		obj[prefixedMethod] = (mock) ? noop : function(url, name) {
+		obj[prefixedMethod] = (mock) ? noop : function (url, name) {
 			var args = slice.call(arguments, 1);
 			args[0] = obj.buildMetricNameForUrl(url, name);
 			client[method].apply(client, args);

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -2,23 +2,22 @@
 'use strict';
 
 // Watch a file tree for changes using Gaze
-module.exports = function(extension) {
-
-	var watchTree = function(directories, log) {
+module.exports = function (extension) {
+	var watchTree = function (directories, log) {
 		var Gaze = require('gaze');
 		var watchedDirs = (typeof directories === 'string') ? constructGlob(directories) : directories.map(constructGlob);
 		var watcher = new Gaze(watchedDirs);
-		watcher.on('added', function(path) {
+		watcher.on('added', function (path) {
 			watcher.emit('fileCreated', path);
 		});
-		watcher.on('changed', function(path) {
+		watcher.on('changed', function (path) {
 			watcher.emit('fileModified', path);
 		});
 		watcher.on('error', log.error);
 		return watcher;
 	};
 
-	var constructGlob = function(dirpath) {
+	var constructGlob = function (dirpath) {
 		var glob = '/**/*' + extension;
 		return dirpath + glob;
 	};

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,7 +1,7 @@
 
 'use strict';
 
-module.exports = function(config) {
+module.exports = function (config) {
 	var connect = require('connect');
 	var bodyParser = require('body-parser');
 	var cookieParser = require('cookie-parser');
@@ -38,7 +38,7 @@ module.exports = function(config) {
 		app.use(config.web.resources, renderer.assetServer());
 	}
 
-	config.middleware.forEach(function(args) {
+	config.middleware.forEach(function (args) {
 		app.use.apply(app, args);
 	});
 
@@ -51,13 +51,13 @@ module.exports = function(config) {
 	app.use(processor.intercept);
 	app.use(processor.proxy);
 
-	app.listen(config.argv.port, function() {
+	app.listen(config.argv.port, function () {
 		config.log.debug('Worker process ' + process.pid + ' started in ' + config.env.name + ' mode, listening on port ' + config.argv.port);
 	});
-	process.on('uncaughtException', function(err) {
+	process.on('uncaughtException', function (err) {
 		if (err.code === 'EADDRINUSE') {
 			config.log.error('Worker process ' + process.pid + ' died, something is already listening on port ' + config.argv.port);
-			// exit with status 0, so server doesn't attempt to respawn
+			// Exit with status 0, so server doesn't attempt to respawn
 			process.exit(0);
 		} else {
 			config.log.error(err);
@@ -65,12 +65,12 @@ module.exports = function(config) {
 		}
 	});
 
-	process.on('message', function(msg) {
+	process.on('message', function (msg) {
 		if (msg === 'force exit') {
 			process.exit(0);
 		}
 	});
-	process.on('disconnect', function() {
+	process.on('disconnect', function () {
 		process.exit(0);
 	});
 };

--- a/package.json
+++ b/package.json
@@ -2,10 +2,8 @@
   "name": "shunter",
   "version": "4.6.1",
   "license": "LGPL-3.0",
-
   "description": "A Node.js application built to read JSON and translate it into HTML",
   "keywords": [ "proxy", "front-end", "dust", "templates", "asset pipeline", "renderer" ],
-
   "author": "Nature Publishing Group",
   "contributors": [
     "Adam Tavener (http://www.tavvy.co.uk/)",
@@ -32,7 +30,6 @@
     "Thomas Franquelin (https://github.com/ostapneko)",
     "Yomi Colledge (http://baphled.wordpress.com)"
   ],
-
   "repository": {
     "type": "git",
     "url": "https://github.com/springernature/shunter.git"
@@ -80,15 +77,13 @@
   },
   "devDependencies": {
     "istanbul": "^0.4.0",
-    "jscs": "^3.0.0",
-    "jshint": "^2.0.0",
     "mocha": "^3.0.0",
     "mockery": "^2.0.0",
     "proclaim": "^3.0.0",
     "sinon": "^2.0.0",
-    "snyk": "^1.29.0"
+    "snyk": "^1.29.0",
+    "xo": "^0.18.2"
   },
-
   "main": "./lib/shunter.js",
   "bin": {
     "shunter-build": "./bin/compile.js",
@@ -98,5 +93,49 @@
   },
   "scripts": {
       "test": "make test"
+  },
+  "xo": {
+    "esnext": false,
+    "envs": [
+      "browser",
+      "jquery"
+    ],
+    "ignore": ["tests/client/lib/*.js"],
+    "rules": {
+      "block-scoped-var": "warn",
+      "no-lonely-if": "warn",
+      "no-multi-assign": "warn",
+      "no-path-concat": "warn",
+      "no-prototype-builtins": "warn",
+      "no-redeclare": "warn",
+      "no-undef": "warn",
+      "no-use-before-define": "warn",
+      "no-useless-escape": "warn",
+      "unicorn/explicit-length-check": "warn",
+      "unicorn/no-new-buffer": "warn"
+    },
+    "overrides": [
+      {
+        "files": "lib/processor.js",
+        "rules": {
+          "import/no-unresolved": "warn",
+          "unicorn/catch-error-name": "warn"
+        }
+      },
+      {
+        "files": "tests/server/core/input-filter.js",
+        "rules": {
+          "no-unused-vars": "warn"
+        }
+      },
+      {
+        "files": "tests/**/*.js",
+        "envs": [
+          "browser",
+          "jquery",
+          "mocha"
+        ]
+      }
+    ]
   }
 }

--- a/tests/server/core/benchmark.js
+++ b/tests/server/core/benchmark.js
@@ -6,10 +6,10 @@ var assert = require('proclaim');
 
 var moduleName = '../../../lib/benchmark';
 
-describe('Benchmarking requests', function() {
+describe('Benchmarking requests', function () {
 	var statsd;
 
-	before(function() {
+	before(function () {
 		mockery.enable({
 			useCleanCache: true,
 			warnOnUnregistered: false,
@@ -20,12 +20,12 @@ describe('Benchmarking requests', function() {
 
 		mockery.registerMock('./statsd', statsd);
 	});
-	after(function() {
+	after(function () {
 		mockery.deregisterAll();
 		mockery.disable();
 	});
 
-	it('Should record the time taken for the request when res.end is called', function() {
+	it('Should record the time taken for the request when res.end is called', function () {
 		var req = {
 			url: '/test'
 		};

--- a/tests/server/core/config.js
+++ b/tests/server/core/config.js
@@ -3,9 +3,9 @@
 var assert = require('proclaim');
 var mockery = require('mockery');
 
-describe('Shunter configuration', function() {
-	describe('No environment specified', function() {
-		it('Should use development as the default environment', function() {
+describe('Shunter configuration', function () {
+	describe('No environment specified', function () {
+		it('Should use development as the default environment', function () {
 			var config = require('../../../lib/config')(null, null, {});
 			assert.equal(config.env.name, 'development');
 			assert.isTrue(config.env.isDevelopment());
@@ -13,10 +13,10 @@ describe('Shunter configuration', function() {
 		});
 	});
 
-	describe('Specifying an environment', function() {
+	describe('Specifying an environment', function () {
 		var env;
 
-		beforeEach(function() {
+		beforeEach(function () {
 			env = process.env.NODE_ENV;
 			process.env.NODE_ENV = 'ci';
 
@@ -27,26 +27,25 @@ describe('Shunter configuration', function() {
 			});
 			mockery.registerMock('os', require('../mocks/os'));
 		});
-		afterEach(function() {
+		afterEach(function () {
 			process.env.NODE_ENV = env;
 
 			mockery.deregisterAll();
 			mockery.disable();
 		});
 
-		it('Should be able to select the environment from an environment variable', function() {
+		it('Should be able to select the environment from an environment variable', function () {
 			var config = require('../../../lib/config')(null, null, {});
 			assert.equal(config.env.name, 'ci');
 			assert.isFalse(config.env.isDevelopment());
 			assert.isFalse(config.env.isProduction());
 		});
 
-		it('Should be able to override an environment variable', function() {
+		it('Should be able to override an environment variable', function () {
 			var config = require('../../../lib/config')('production', null, {});
 			assert.equal(config.env.name, 'production');
 			assert.isTrue(config.env.isProduction());
 			assert.isFalse(config.env.isDevelopment());
 		});
-
 	});
 });

--- a/tests/server/core/content-type.js
+++ b/tests/server/core/content-type.js
@@ -4,25 +4,25 @@ var assert = require('proclaim');
 
 var moduleName = '../../../lib/content-type';
 
-describe('Get the content type', function() {
-	it('Should find the content type from the file extension', function() {
+describe('Get the content type', function () {
+	it('Should find the content type from the file extension', function () {
 		var contentType = require(moduleName);
 		assert.equal(contentType('/nutd/sitemap.xml'), 'application/xml');
 		assert.equal(contentType('file.txt'), 'text/plain');
 	});
 
-	it('Should allow the charset to be specified', function() {
+	it('Should allow the charset to be specified', function () {
 		var contentType = require(moduleName);
 		assert.equal(contentType('/nutd/sitemap.xml', {charset: 'utf-8'}), 'application/xml; charset=utf-8');
 		assert.equal(contentType('file.txt', {charset: 'ISO-8859-8'}), 'text/plain; charset=ISO-8859-8');
 	});
 
-	it('Should find the content type from the file extension ignoring any query params', function() {
+	it('Should find the content type from the file extension ignoring any query params', function () {
 		var contentType = require(moduleName);
 		assert.equal(contentType('/feed.atom?foo=bar'), 'application/atom+xml');
 	});
 
-	it('Should fall back to text/html as default', function() {
+	it('Should fall back to text/html as default', function () {
 		var contentType = require(moduleName);
 		assert.equal(contentType('foo'), 'text/html');
 		assert.equal(contentType('bar.html'), 'text/html');

--- a/tests/server/core/dispatch.js
+++ b/tests/server/core/dispatch.js
@@ -6,7 +6,7 @@ var mockery = require('mockery');
 
 var moduleName = '../../../lib/dispatch';
 
-describe('Dispatching response', function() {
+describe('Dispatching response', function () {
 	var config;
 	var contentType;
 	var createFilter;
@@ -14,7 +14,7 @@ describe('Dispatching response', function() {
 	var req;
 	var res;
 
-	beforeEach(function() {
+	beforeEach(function () {
 		mockery.enable({
 			useCleanCache: true,
 			warnOnUnregistered: false,
@@ -25,7 +25,6 @@ describe('Dispatching response', function() {
 
 		filter = sinon.stub().returnsArg(0);
 		createFilter = sinon.stub().returns(filter);
-
 
 		mockery.registerMock('./output-filter', createFilter);
 		req = require('../mocks/request');
@@ -74,19 +73,19 @@ describe('Dispatching response', function() {
 			}
 		};
 	});
-	afterEach(function() {
+	afterEach(function () {
 		mockery.deregisterAll();
 		mockery.disable();
 	});
 
-	it('Should set the content type header', function() {
+	it('Should set the content type header', function () {
 		var dispatch = require(moduleName)(config);
 
 		dispatch.send(null, 'hello', req, res);
 		assert.isTrue(res.setHeader.calledWith('Content-type', 'text/html; charset=utf-8'));
 	});
 
-	it('Should set the correct content type if the json parameter is set', function() {
+	it('Should set the correct content type if the json parameter is set', function () {
 		var dispatch = require(moduleName)(config);
 		req.isJson = true;
 
@@ -97,14 +96,14 @@ describe('Dispatching response', function() {
 		assert.isTrue(res.end.calledOnce);
 	});
 
-	it('Should take multibyte characaters into account when setting the content length header', function() {
+	it('Should take multibyte characaters into account when setting the content length header', function () {
 		var dispatch = require(moduleName)(config);
 
 		dispatch.send(null, 'hello¡', req, res);
 		assert.isTrue(res.setHeader.calledWith('Content-length', 7));
 	});
 
-	it('Should default to a 200 status if there was no error', function() {
+	it('Should default to a 200 status if there was no error', function () {
 		var dispatch = require(moduleName)(config);
 
 		dispatch.send(null, 'hello', req, res);
@@ -113,7 +112,7 @@ describe('Dispatching response', function() {
 		assert.isTrue(res.end.calledOnce);
 	});
 
-	it('Should allow the status code to be passed to it', function() {
+	it('Should allow the status code to be passed to it', function () {
 		var dispatch = require(moduleName)(config);
 
 		dispatch.send(null, 'not allowed', req, res, 401);
@@ -122,7 +121,7 @@ describe('Dispatching response', function() {
 		assert.isTrue(res.end.calledOnce);
 	});
 
-	it('Should set a 500 status if there was an error', function() {
+	it('Should set a 500 status if there was an error', function () {
 		var dispatch = require(moduleName)(config);
 
 		dispatch.send({message: 'fail'}, 'hello', req, res, 200);

--- a/tests/server/core/dust.js
+++ b/tests/server/core/dust.js
@@ -1,11 +1,10 @@
-// jscs:disable requireCamelCaseOrUpperCaseIdentifiers
+/* eslint-disable camelcase */
 'use strict';
 
 var assert = require('proclaim');
 var sinon = require('sinon');
 
-
-describe('Template loading', function() {
+describe('Template loading', function () {
 	var dust = require('dustjs-helpers');
 	var mockConfig = {
 		argv: {},
@@ -18,9 +17,9 @@ describe('Template loading', function() {
 	var options;
 	var callback;
 
-	var createMockCache = function(obj) {
+	var createMockCache = function (obj) {
 		var cache = {};
-		Object.keys(obj).forEach(function(key) {
+		Object.keys(obj).forEach(function (key) {
 			cache[mockRenderer.TEMPLATE_CACHE_KEY_PREFIX + '__' + key] = obj[key];
 		});
 		return cache;
@@ -28,17 +27,17 @@ describe('Template loading', function() {
 
 	require('../../../lib/dust')(dust, mockRenderer, mockConfig);
 
-	beforeEach(function() {
+	beforeEach(function () {
 		dust.cache = {};
 		options = {};
 		callback = sinon.stub();
 	});
-	afterEach(function() {
+	afterEach(function () {
 		mockConfig.log.warn.reset();
 		mockRenderer.compileOnDemand.reset();
 	});
 
-	it('Should log and gracefully handle missing templates', function() {
+	it('Should log and gracefully handle missing templates', function () {
 		dust.onLoad('nonexistent', options, callback);
 		assert(mockConfig.log.warn.calledOnce);
 		assert.match(mockConfig.log.warn.lastCall.args[0], /nonexistent$/i);
@@ -47,14 +46,14 @@ describe('Template loading', function() {
 		assert.strictEqual(callback.lastCall.args[1], '');
 	});
 
-	it('Should attempt to compile unknown templates if `compile-on-demand` is enabled', function() {
+	it('Should attempt to compile unknown templates if `compile-on-demand` is enabled', function () {
 		mockConfig.argv['compile-on-demand'] = true;
 		dust.onLoad('notloaded', options, callback);
 		assert(mockRenderer.compileOnDemand.calledOnce);
 		assert(mockRenderer.compileOnDemand.calledWith('notloaded'));
 	});
 
-	it('Should load a given template from its keyname in the dust cache', function() {
+	it('Should load a given template from its keyname in the dust cache', function () {
 		var templateStub = sinon.stub();
 		dust.cache = createMockCache({
 			foo: templateStub
@@ -65,7 +64,7 @@ describe('Template loading', function() {
 		assert.strictEqual(callback.lastCall.args[1], templateStub);
 	});
 
-	it('Should use a nested template instead of the default one', function() {
+	it('Should use a nested template instead of the default one', function () {
 		var templateStub = sinon.stub();
 		var parentStub = sinon.stub();
 		var rootStub = sinon.stub();
@@ -84,8 +83,7 @@ describe('Template loading', function() {
 		assert.equal(callback.lastCall.args[1], templateStub);
 	});
 
-
-	it('Should use the parent-level (app-level) template if a nested (project-level) one cannot be found', function() {
+	it('Should use the parent-level (app-level) template if a nested (project-level) one cannot be found', function () {
 		var parentStub = sinon.stub();
 		var rootStub = sinon.stub();
 
@@ -102,7 +100,7 @@ describe('Template loading', function() {
 		assert.equal(callback.lastCall.args[1], parentStub);
 	});
 
-	it('Should use the default root-level template if no namespaced template can be found', function() {
+	it('Should use the default root-level template if no namespaced template can be found', function () {
 		var rootStub = sinon.stub();
 
 		options = {
@@ -117,7 +115,7 @@ describe('Template loading', function() {
 		assert.equal(callback.lastCall.args[1], rootStub);
 	});
 
-	it('Should check the full template name in the local namespace', function() {
+	it('Should check the full template name in the local namespace', function () {
 		var localStub = sinon.stub();
 		var parentStub = sinon.stub();
 		var rootStub = sinon.stub();
@@ -136,7 +134,7 @@ describe('Template loading', function() {
 		assert.equal(callback.lastCall.args[1], localStub);
 	});
 
-	it('Should check the full template name in the parent namespace', function() {
+	it('Should check the full template name in the parent namespace', function () {
 		var parentStub = sinon.stub();
 		var rootStub = sinon.stub();
 
@@ -153,7 +151,7 @@ describe('Template loading', function() {
 		assert.equal(callback.lastCall.args[1], parentStub);
 	});
 
-	it('Should check the full template name in the root namespace', function() {
+	it('Should check the full template name in the root namespace', function () {
 		var rootStub = sinon.stub();
 
 		options = {
@@ -168,7 +166,7 @@ describe('Template loading', function() {
 		assert.equal(callback.lastCall.args[1], rootStub);
 	});
 
-	it('Should check the namespace contains the full path for the template', function() {
+	it('Should check the namespace contains the full path for the template', function () {
 		var localStub = sinon.stub();
 		var parentStub = sinon.stub();
 		var rootStub = sinon.stub();
@@ -186,5 +184,4 @@ describe('Template loading', function() {
 		assert.equal(callback.lastCall.args[0], null);
 		assert.equal(callback.lastCall.args[1], parentStub);
 	});
-
 });

--- a/tests/server/core/error-pages.js
+++ b/tests/server/core/error-pages.js
@@ -6,7 +6,7 @@ var mockery = require('mockery');
 
 var moduleName = '../../../lib/error-pages';
 
-describe('Templating error pages', function() {
+describe('Templating error pages', function () {
 	var config;
 	var contentType;
 	var createFilter;
@@ -16,7 +16,7 @@ describe('Templating error pages', function() {
 	var error;
 	var renderer;
 
-	beforeEach(function() {
+	beforeEach(function () {
 		mockery.enable({
 			useCleanCache: true,
 			warnOnUnregistered: false,
@@ -88,7 +88,7 @@ describe('Templating error pages', function() {
 			}
 		};
 	});
-	afterEach(function() {
+	afterEach(function () {
 		mockery.deregisterAll();
 		mockery.disable();
 	});
@@ -96,12 +96,12 @@ describe('Templating error pages', function() {
 	error = new Error('Some kind of error');
 	error.status = 418;
 
-	it('Should callback with null if not configured to use templated pages', function() {
+	it('Should callback with null if not configured to use templated pages', function () {
 		var unconfiguredConfig = config;
 		unconfiguredConfig.errorPages = {};
 		var errorPages = require(moduleName)(unconfiguredConfig);
 		var retval = false;
-		errorPages.getPage(error, req, res, function(ret) {
+		errorPages.getPage(error, req, res, function (ret) {
 			retval = ret;
 		});
 
@@ -109,10 +109,10 @@ describe('Templating error pages', function() {
 		assert.strictEqual(null, retval);
 	});
 
-	it('Should try to render if configured to do so', function() {
+	it('Should try to render if configured to do so', function () {
 		var errorPages = require(moduleName)(config);
 		var retval = false;
-		errorPages.getPage(error, req, res, function(ret) {
+		errorPages.getPage(error, req, res, function (ret) {
 			retval = ret;
 		});
 
@@ -122,10 +122,10 @@ describe('Templating error pages', function() {
 		assert.strictEqual('my error page', retval);
 	});
 
-	it('Should callback with null if there is an error rendering the error page', function() {
+	it('Should callback with null if there is an error rendering the error page', function () {
 		var errorPages = require(moduleName)(config);
 		var retval = false;
-		errorPages.getPage(error, req, res, function(ret) {
+		errorPages.getPage(error, req, res, function (ret) {
 			retval = ret;
 		});
 
@@ -135,53 +135,52 @@ describe('Templating error pages', function() {
 		assert.strictEqual(null, retval);
 	});
 
-	it('Should render the template with the users specified default layout', function() {
+	it('Should render the template with the users specified default layout', function () {
 		var errorPages = require(moduleName)(config);
-		errorPages.getPage(error, req, res, function() { });
+		errorPages.getPage(error, req, res, function () { });
 		assert.strictEqual(config.errorPages.errorLayouts.default, renderer.render.firstCall.args[2].layout.template);
 	});
 
-	it('Should render the template with the users specified layout by error code', function() {
+	it('Should render the template with the users specified layout by error code', function () {
 		var errorPages = require(moduleName)(config);
 		var error = new Error('err');
 		error.status = 404;
-		errorPages.getPage(error, req, res, function() { });
+		errorPages.getPage(error, req, res, function () { });
 		assert.strictEqual(config.errorPages.errorLayouts[error.status.toString()], renderer.render.firstCall.args[2].layout.template);
 	});
 
-	it('Should insert the error into the template context', function() {
+	it('Should insert the error into the template context', function () {
 		var errorPages = require(moduleName)(config);
-		errorPages.getPage(error, req, res, function() { });
+		errorPages.getPage(error, req, res, function () { });
 		assert.strictEqual(error, renderer.render.firstCall.args[2].errorContext.error);
 	});
 
-	it('Should populate the template context with the reqHost', function() {
+	it('Should populate the template context with the reqHost', function () {
 		var errorPages = require(moduleName)(config);
-		errorPages.getPage(error, req, res, function() { });
+		errorPages.getPage(error, req, res, function () { });
 		assert.strictEqual(req.headers.host, renderer.render.firstCall.args[2].errorContext.reqHost);
 	});
 
-	it('Should populate the template context with the users static data', function() {
+	it('Should populate the template context with the users static data', function () {
 		var errorPages = require(moduleName)(config);
-		errorPages.getPage(error, req, res, function() { });
+		errorPages.getPage(error, req, res, function () { });
 		assert.strictEqual(config.errorPages.staticData.users, renderer.render.firstCall.args[2].users);
 	});
 
-	it('Should prevent the user from clobbering the required "layout" key', function() {
+	it('Should prevent the user from clobbering the required "layout" key', function () {
 		config.errorPages.staticData.layout = {};
 		var errorPages = require(moduleName)(config);
-		errorPages.getPage(error, req, res, function() { });
+		errorPages.getPage(error, req, res, function () { });
 		assert.strictEqual(config.errorPages.errorLayouts.default, renderer.render.firstCall.args[2].layout.template);
 	});
 
-	it('Should prevent the user from clobbering the required "errorContext" key', function() {
+	it('Should prevent the user from clobbering the required "errorContext" key', function () {
 		var badConfig = {
 			user: 'error'
 		};
 		config.errorPages.staticData.errorContext = badConfig;
 		var errorPages = require(moduleName)(config);
-		errorPages.getPage(error, req, res, function() { });
+		errorPages.getPage(error, req, res, function () { });
 		assert.notStrictEqual(badConfig, renderer.render.firstCall.args[2].errorContext);
-
 	});
 });

--- a/tests/server/core/input-filter.js
+++ b/tests/server/core/input-filter.js
@@ -3,11 +3,11 @@
 var assert = require('proclaim');
 var sinon = require('sinon');
 
-describe('Input filtering', function() {
+describe('Input filtering', function () {
 	var filter;
 	var config;
 
-	beforeEach(function() {
+	beforeEach(function () {
 		config = {
 			test: 'fake config',
 			log: require('../mocks/log')
@@ -15,8 +15,8 @@ describe('Input filtering', function() {
 		filter = require('../../../lib/input-filter')(config);
 	});
 
-	describe('Filter helpers', function() {
-		it('Should find a whether a key exists in the article context', function() {
+	describe('Filter helpers', function () {
+		it('Should find a whether a key exists in the article context', function () {
 			var data = {
 				article: {
 					test: 'pass'
@@ -26,7 +26,7 @@ describe('Input filtering', function() {
 			assert.strictEqual(filter.getBase(data, 'test').test, 'pass');
 		});
 
-		it('Should find whether a key exists in the global context', function() {
+		it('Should find whether a key exists in the global context', function () {
 			var data = {
 				article: {
 					test2: 'fail'
@@ -36,7 +36,7 @@ describe('Input filtering', function() {
 			assert.strictEqual(filter.getBase(data, 'test').test, 'pass');
 		});
 
-		it('Should return null if the key is not found', function() {
+		it('Should return null if the key is not found', function () {
 			var data = {
 				article: {
 					test2: 'fail'
@@ -47,28 +47,26 @@ describe('Input filtering', function() {
 		});
 	});
 
-	describe('Creating filters', function() {
-		it('Should create an empty list of filters', function() {
+	describe('Creating filters', function () {
+		it('Should create an empty list of filters', function () {
 			assert.isArray(filter.filters);
 			assert.strictEqual(filter.filters.length, 0);
 		});
 
-		it('Should allow filters to be added', function() {
+		it('Should allow filters to be added', function () {
 			filter.add(sinon.stub());
 			assert.strictEqual(filter.filters.length, 1);
 		});
 	});
 
-	describe('Running filters', function() {
-		it('Should apply all filters in the list in order', function() {
+	describe('Running filters', function () {
+		it('Should apply all filters in the list in order', function () {
 			var callback = sinon.stub();
 
-			var spy1 = sinon.spy(function(data) {
-				// jshint unused: false
+			var spy1 = sinon.spy(function (data) {
 				return 'filter 1';
 			});
-			var spy2 = sinon.spy(function(data) {
-				// jshint unused: false
+			var spy2 = sinon.spy(function (data) {
 				return 'filter 2';
 			});
 
@@ -85,10 +83,10 @@ describe('Input filtering', function() {
 			assert.isTrue(callback.calledWith('filter 2'));
 		});
 
-		it('Should pass a callback if the filter specifies a second argument', function() {
+		it('Should pass a callback if the filter specifies a second argument', function () {
 			var callback = sinon.stub();
 
-			var spy = sinon.spy(function(data, fn) {
+			var spy = sinon.spy(function (data, fn) {
 				fn('filter 1');
 			});
 
@@ -103,10 +101,10 @@ describe('Input filtering', function() {
 			assert.isTrue(callback.calledWith('filter 1'));
 		});
 
-		it('Should additionally provide config if the filter specifies three arguments', function() {
+		it('Should additionally provide config if the filter specifies three arguments', function () {
 			var callback = sinon.stub();
 
-			var spy = sinon.spy(function(config, data, fn) {
+			var spy = sinon.spy(function (config, data, fn) {
 				fn('filter 1');
 			});
 
@@ -121,10 +119,10 @@ describe('Input filtering', function() {
 			assert.isTrue(callback.calledWith('filter 1'));
 		});
 
-		it('Should additionally provide the request and response if the filter specifies five arguments', function() {
+		it('Should additionally provide the request and response if the filter specifies five arguments', function () {
 			var callback = sinon.stub();
 
-			var spy = sinon.spy(function(config, req, res, data, fn) {
+			var spy = sinon.spy(function (config, req, res, data, fn) {
 				fn('filter 1');
 			});
 
@@ -139,18 +137,16 @@ describe('Input filtering', function() {
 			assert.isTrue(callback.calledWith('filter 1'));
 		});
 
-		it('Should skip a filter that defines an unsupported number of arguments', function() {
+		it('Should skip a filter that defines an unsupported number of arguments', function () {
 			var callback = sinon.stub();
 
-			var spy1 = sinon.spy(function() {
+			var spy1 = sinon.spy(function () {
 				return 'filter 1';
 			});
-			var spy2 = sinon.spy(function(arg1, arg2, arg3, arg4) {
-				// jshint unused: false
+			var spy2 = sinon.spy(function (arg1, arg2, arg3, arg4) {
 				return 'filter 2';
 			});
-			var spy3 = sinon.spy(function(arg1, arg2, arg3, arg4, arg5, arg6) {
-				// jshint unused: false
+			var spy3 = sinon.spy(function (arg1, arg2, arg3, arg4, arg5, arg6) {
 				return 'filter 3';
 			});
 
@@ -167,20 +163,19 @@ describe('Input filtering', function() {
 			assert.isTrue(callback.calledWith('init'));
 		});
 
-		it('Should run each filter with the input-filter as the caller object', function() {
+		it('Should run each filter with the input-filter as the caller object', function () {
 			var callback = sinon.stub();
 
-			var spy1 = sinon.spy(function(data) {
-				// jshint unused: false
+			var spy1 = sinon.spy(function (data) {
 				return 'filter 1';
 			});
-			var spy2 = sinon.spy(function(data, fn) {
+			var spy2 = sinon.spy(function (data, fn) {
 				fn('filter 2');
 			});
-			var spy3 = sinon.spy(function(config, data, fn) {
+			var spy3 = sinon.spy(function (config, data, fn) {
 				fn('filter 3');
 			});
-			var spy4 = sinon.spy(function(config, req, res, data, fn) {
+			var spy4 = sinon.spy(function (config, req, res, data, fn) {
 				fn('filter 4');
 			});
 

--- a/tests/server/core/map-route.js
+++ b/tests/server/core/map-route.js
@@ -4,58 +4,57 @@ var assert = require('proclaim');
 
 var moduleName = '../../../lib/map-route';
 
-describe('Mapping a route', function() {
-
-	it('Should map a route with a protocol, hostname and port', function() {
+describe('Mapping a route', function () {
+	it('Should map a route with a protocol, hostname and port', function () {
 		var route = require(moduleName)('http://www.foo.com:80');
 		assert.equal(route.protocol, 'http:');
 		assert.equal(route.host, 'www.foo.com');
 		assert.equal(route.port, 80);
 	});
 
-	it('Should map a route with a protocol, subdomain, hostname and port', function() {
+	it('Should map a route with a protocol, subdomain, hostname and port', function () {
 		var route = require(moduleName)('https://foo-www.somehost-name.bar.com:80');
 		assert.equal(route.protocol, 'https:');
 		assert.equal(route.host, 'foo-www.somehost-name.bar.com');
 		assert.equal(route.port, 80);
 	});
 
-	it('Should map a route with a protocol, subdomain, hostname and no port', function() {
+	it('Should map a route with a protocol, subdomain, hostname and no port', function () {
 		var route = require(moduleName)('http://somehost-name.foo.com');
 		assert.equal(route.protocol, 'http:');
 		assert.equal(route.host, 'somehost-name.foo.com');
 		assert.equal(route.port, null);
 	});
 
-	it('Should map a route with an IPv4 address and port', function() {
+	it('Should map a route with an IPv4 address and port', function () {
 		var route = require(moduleName)('127.0.0.1:9000');
 		assert.equal(route.protocol, 'http:');
 		assert.equal(route.host, '127.0.0.1');
 		assert.equal(route.port, 9000);
 	});
 
-	it('Should map a route with an IPv4 address and no port', function() {
+	it('Should map a route with an IPv4 address and no port', function () {
 		var route = require(moduleName)('8.8.8.8');
 		assert.equal(route.protocol, 'http:');
 		assert.equal(route.host, '8.8.8.8');
 		assert.equal(route.port, null);
 	});
 
-	it('Should map a route with a protocol and a IPv4 address and a port', function() {
+	it('Should map a route with a protocol and a IPv4 address and a port', function () {
 		var route = require(moduleName)('https://8.8.8.8:80');
 		assert.equal(route.protocol, 'https:');
 		assert.equal(route.host, '8.8.8.8');
 		assert.equal(route.port, 80);
 	});
 
-	it('Should map a route with a protocol and a IPv4 address and no port', function() {
+	it('Should map a route with a protocol and a IPv4 address and no port', function () {
 		var route = require(moduleName)('https://8.8.8.8');
 		assert.equal(route.protocol, 'https:');
 		assert.equal(route.host, '8.8.8.8');
 		assert.equal(route.port, null);
 	});
 
-	it('Should default to mapping a hostname protocol to http', function() {
+	it('Should default to mapping a hostname protocol to http', function () {
 		var route = require(moduleName);
 		assert.equal(route('localhost').host, 'localhost');
 		assert.equal(route('localhost').protocol, 'http:');
@@ -63,5 +62,4 @@ describe('Mapping a route', function() {
 		assert.equal(route('foo.com').host, 'foo.com');
 		assert.equal(route('localhost').protocol, 'http:');
 	});
-
 });

--- a/tests/server/core/output-filter.js
+++ b/tests/server/core/output-filter.js
@@ -4,7 +4,7 @@ var assert = require('proclaim');
 var mockery = require('mockery');
 var sinon = require('sinon');
 
-describe('Output filtering', function() {
+describe('Output filtering', function () {
 	var config;
 	var filter;
 	var eachModule;
@@ -14,26 +14,26 @@ describe('Output filtering', function() {
 	var filter4;
 	var filter5;
 
-	beforeEach(function() {
+	beforeEach(function () {
 		mockery.enable({
 			useCleanCache: true,
 			warnOnUnregistered: false,
 			warnOnReplace: false
 		});
 
-		filter1 = sinon.spy(function(content) {
+		filter1 = sinon.spy(function (content) {
 			return content + ':content';
 		});
-		filter2 = sinon.spy(function(content, contentType) {
+		filter2 = sinon.spy(function (content, contentType) {
 			return content + ':contentType=' + contentType;
 		});
-		filter3 = sinon.spy(function(content, contentType, req) {
+		filter3 = sinon.spy(function (content, contentType, req) {
 			return content + ':req.url=' + req.url;
 		});
-		filter4 = sinon.spy(function(content, contentType, req, config) {
+		filter4 = sinon.spy(function (content, contentType, req, config) {
 			return content + ':config.foo=' + config.foo;
 		});
-		filter5 = sinon.spy(function() { });
+		filter5 = sinon.spy(function () { });
 
 		eachModule = require('../mocks/each-module');
 		mockery.registerMock('each-module', eachModule);
@@ -59,16 +59,16 @@ describe('Output filtering', function() {
 		filter = require('../../../lib/output-filter')(config);
 	});
 
-	afterEach(function() {
+	afterEach(function () {
 		mockery.deregisterAll();
 		mockery.disable();
 	});
 
-	it('Should load filters from each of the expected locations', function() {
+	it('Should load filters from each of the expected locations', function () {
 		assert.strictEqual(eachModule.callCount, 5);
 	});
 
-	it('Should load filters in the expected order', function() {
+	it('Should load filters in the expected order', function () {
 		sinon.assert.callOrder(
 			eachModule.withArgs('/app/node_modules/shunter/filters/output'),
 			eachModule.withArgs('/app/node_modules/foo/filters/output'),
@@ -78,7 +78,7 @@ describe('Output filtering', function() {
 		);
 	});
 
-	it('Should call each filter with the correct args', function() {
+	it('Should call each filter with the correct args', function () {
 		var result = filter('text', 'text/html', {url: '/foo'});
 		assert.strictEqual(result, 'text:content:contentType=text/html:req.url=/foo:config.foo=foo');
 	});

--- a/tests/server/core/processor.js
+++ b/tests/server/core/processor.js
@@ -16,10 +16,8 @@ var mockConfig = {
 	argv: {}
 };
 
-describe('Request processor', function() {
-	// jscs:disable disallowDanglingUnderscores
-
-	beforeEach(function() {
+describe('Request processor', function () {
+	beforeEach(function () {
 		mockery.enable({
 			useCleanCache: true,
 			warnOnUnregistered: false,
@@ -37,20 +35,20 @@ describe('Request processor', function() {
 		mockery.registerMock('http-proxy', require('../mocks/http-proxy'));
 		mockery.registerMock('url', require('../mocks/url'));
 	});
-	afterEach(function() {
+	afterEach(function () {
 		mockery.deregisterAll();
 		mockery.disable();
 	});
 
-	describe('Configuring the proxy', function() {
-		it('Should not enable `autoRewrite` and `protocolRewrite` by default', function() {
+	describe('Configuring the proxy', function () {
+		it('Should not enable `autoRewrite` and `protocolRewrite` by default', function () {
 			var proxy = require('http-proxy');
 			require(moduleName)(mockConfig, {});
 			assert.isFalse(proxy.createProxyServer.firstCall.args[0].autoRewrite);
 			assert.isNull(proxy.createProxyServer.firstCall.args[0].protocolRewrite);
 		});
 
-		it('Should allow `autoRewrite` and `protocolRewrite` to be configured', function() {
+		it('Should allow `autoRewrite` and `protocolRewrite` to be configured', function () {
 			mockConfig.argv['rewrite-redirect'] = true;
 			mockConfig.argv['rewrite-protocol'] = 'http';
 
@@ -63,14 +61,14 @@ describe('Request processor', function() {
 		});
 	});
 
-	describe('Modifying the request', function() {
+	describe('Modifying the request', function () {
 		var req;
 
-		beforeEach(function() {
+		beforeEach(function () {
 			req = require('../mocks/request');
 		});
 
-		it('Should add a header X-Shunter-Deploy-Timestamp with the deployment timestamp', function() {
+		it('Should add a header X-Shunter-Deploy-Timestamp with the deployment timestamp', function () {
 			var processor = require(moduleName)(mockConfig, {});
 			var next = sinon.stub();
 
@@ -83,7 +81,7 @@ describe('Request processor', function() {
 			mockConfig.argv = {};
 		});
 
-		it('Should add a header X-Shunter with the Shunter version being used', function() {
+		it('Should add a header X-Shunter with the Shunter version being used', function () {
 			var processor = require(moduleName)(mockConfig, {});
 			var next = sinon.stub();
 
@@ -94,21 +92,21 @@ describe('Request processor', function() {
 		});
 	});
 
-	describe('Intercepting response', function() {
+	describe('Intercepting response', function () {
 		var res;
 		var renderer;
 		var mockTimer;
 
-		beforeEach(function() {
+		beforeEach(function () {
 			renderer = require('../mocks/renderer')();
 			res = require('../mocks/response');
 			mockTimer = sinon.stub().returns(sinon.stub());
 		});
-		afterEach(function() {
+		afterEach(function () {
 			renderer.render.reset();
 		});
 
-		it('Should pass through responses that don\'t have the x-shunter+json mime type', function() {
+		it('Should pass through responses that don\'t have the x-shunter+json mime type', function () {
 			var processor = require(moduleName)({
 				argv: {},
 				timer: mockTimer
@@ -124,7 +122,7 @@ describe('Request processor', function() {
 			assert.isTrue(res.__originalWriteHead.calledOnce);
 		});
 
-		it('Should intercept responses with an x-shunter+json mime type', function() {
+		it('Should intercept responses with an x-shunter+json mime type', function () {
 			var tier = sinon.stub();
 			var processor = require(moduleName)({
 				env: {
@@ -148,7 +146,7 @@ describe('Request processor', function() {
 			assert.equal(renderer.render.firstCall.args[2].foo, 'bar');
 		});
 
-		it('Should JSON if the `jsonViewParameter` parameter is present', function() {
+		it('Should JSON if the `jsonViewParameter` parameter is present', function () {
 			var processor = require(moduleName)({
 				env: {
 					tier: sinon.stub()
@@ -180,7 +178,7 @@ describe('Request processor', function() {
 			assert.equal(dispatch.send.firstCall.args[1], '{\n\t"foo": "bar"\n}');
 		});
 
-		it('Should construct responses across multiple writes', function() {
+		it('Should construct responses across multiple writes', function () {
 			var tier = sinon.stub();
 			var processor = require(moduleName)({
 				env: {
@@ -205,12 +203,12 @@ describe('Request processor', function() {
 			assert.equal(renderer.render.firstCall.args[2].foo, 'bar');
 		});
 
-		it('Should safely reconstruct multibyte characters that are split between writes', function() {
+		it('Should safely reconstruct multibyte characters that are split between writes', function () {
 			var value = 'abc⩽def';
 			var raw = '{"foo":"' + value + '"}';
 			var source = new Buffer(raw);
 			var length = Buffer.byteLength(raw);
-			var firstChunkLength = raw.indexOf('c') + 2; // split in the middle of the ⩽ character
+			var firstChunkLength = raw.indexOf('c') + 2; // Split in the middle of the ⩽ character
 			var secondChunkLength = length - firstChunkLength;
 			var firstChunk = new Buffer(firstChunkLength);
 			var secondChunk = new Buffer(secondChunkLength);
@@ -242,7 +240,7 @@ describe('Request processor', function() {
 			assert.equal(renderer.render.firstCall.args[2].foo, value);
 		});
 
-		it('Should send the rendered page', function() {
+		it('Should send the rendered page', function () {
 			var tier = sinon.stub();
 			var processor = require(moduleName)({
 				env: {
@@ -271,7 +269,7 @@ describe('Request processor', function() {
 			assert.equal(dispatch.send.firstCall.args[1], 'Content');
 		});
 
-		it('Should proxy the status code of the response', function() {
+		it('Should proxy the status code of the response', function () {
 			var tier = sinon.stub();
 			var processor = require(moduleName)({
 				env: {
@@ -301,7 +299,7 @@ describe('Request processor', function() {
 			assert.equal(dispatch.send.firstCall.args[4], 401);
 		});
 
-		it('Should pass through HEAD requests', function() {
+		it('Should pass through HEAD requests', function () {
 			var processor = require(moduleName)({
 				argv: {},
 				timer: mockTimer
@@ -317,7 +315,7 @@ describe('Request processor', function() {
 			assert.isTrue(res.__originalWriteHead.calledOnce);
 		});
 
-		it('Should handle JSON errors', function() {
+		it('Should handle JSON errors', function () {
 			var processor = require(moduleName)(mockConfig, renderer);
 			var dispatch = require('./dispatch')();
 			var callback = sinon.stub();
@@ -329,7 +327,7 @@ describe('Request processor', function() {
 
 			res.writeHead();
 			res.write(new Buffer('{"foo":bar"}'));
-			assert.doesNotThrow(function() {
+			assert.doesNotThrow(function () {
 				res.end();
 			});
 			assert.equal(renderer.render.callCount, 0);
@@ -337,7 +335,7 @@ describe('Request processor', function() {
 			assert.instanceOf(dispatch.send.firstCall.args[0], Error);
 		});
 
-		it('Should reset the response methods once we\'re done buffering the response', function() {
+		it('Should reset the response methods once we\'re done buffering the response', function () {
 			var processor = require(moduleName)(mockConfig, {});
 			var callback = sinon.stub();
 
@@ -357,8 +355,8 @@ describe('Request processor', function() {
 		});
 	});
 
-	describe('Ping', function() {
-		it('Should send a 200 OK response', function() {
+	describe('Ping', function () {
+		it('Should send a 200 OK response', function () {
 			var req = require('../mocks/request');
 			var res = require('../mocks/response');
 			var processor = require(moduleName)(mockConfig, {});
@@ -369,22 +367,22 @@ describe('Request processor', function() {
 		});
 	});
 
-	describe('API', function() {
+	describe('API', function () {
 		var processor;
 		var renderer;
 		var dispatch;
 
-		beforeEach(function() {
+		beforeEach(function () {
 			renderer = require('../mocks/renderer')();
 			dispatch = require('./dispatch')();
 			processor = processor = require(moduleName)(mockConfig, renderer);
 		});
 
-		afterEach(function() {
+		afterEach(function () {
 			renderer.renderPartial.reset();
 		});
 
-		it('Should allow the template to be specified in the url', function() {
+		it('Should allow the template to be specified in the url', function () {
 			var req = {
 				url: '/hello',
 				body: {world: true}
@@ -395,7 +393,7 @@ describe('Request processor', function() {
 			assert.isTrue(renderer.renderPartial.calledWith('hello', req, res, req.body));
 		});
 
-		it('Should allow the template to be specified in the request body', function() {
+		it('Should allow the template to be specified in the request body', function () {
 			var req = {
 				url: '/',
 				body: {
@@ -411,7 +409,7 @@ describe('Request processor', function() {
 			assert.isTrue(renderer.renderPartial.calledWith('layout', req, res, req.body));
 		});
 
-		it('Should convert the path to a template name', function() {
+		it('Should convert the path to a template name', function () {
 			var req = {
 				url: '/hello/world/test',
 				body: {world: true}
@@ -422,7 +420,7 @@ describe('Request processor', function() {
 			assert.isTrue(renderer.renderPartial.calledWith('hello__world__test', req, res, req.body));
 		});
 
-		it('Should return a 404 error if none of the required information is available', function() {
+		it('Should return a 404 error if none of the required information is available', function () {
 			var req = {
 				url: '/',
 				body: {}
@@ -435,7 +433,7 @@ describe('Request processor', function() {
 			assert.strictEqual(dispatch.send.firstCall.args[0].status, 404);
 		});
 
-		it('Should return a 404 error if some of required information is missing', function() {
+		it('Should return a 404 error if some of required information is missing', function () {
 			var req = {
 				url: '/',
 				body: {
@@ -453,16 +451,16 @@ describe('Request processor', function() {
 		});
 	});
 
-	describe('Proxy', function() {
+	describe('Proxy', function () {
 		var processor;
 		var dispatch;
 
-		beforeEach(function() {
+		beforeEach(function () {
 			processor = require(moduleName)(mockConfig, {});
 			dispatch = require('./dispatch')();
 		});
 
-		it('Should proxy requests to the matching route', function() {
+		it('Should proxy requests to the matching route', function () {
 			var req = {};
 			var res = {};
 			var stub = sinon.stub();
@@ -479,7 +477,7 @@ describe('Request processor', function() {
 			assert.strictEqual(stub.firstCall.args[2].target, 'http://www.nature.com:1337');
 		});
 
-		it('Should default to no port', function() {
+		it('Should default to no port', function () {
 			var req = {};
 			var res = {};
 			var stub = sinon.stub();
@@ -495,7 +493,7 @@ describe('Request processor', function() {
 			assert.strictEqual(stub.firstCall.args[2].target, 'http://www.nature.com');
 		});
 
-		it('Should pass a port if one is specified', function() {
+		it('Should pass a port if one is specified', function () {
 			var req = {};
 			var res = {};
 			var stub = sinon.stub();
@@ -512,7 +510,7 @@ describe('Request processor', function() {
 			assert.strictEqual(stub.firstCall.args[2].target, 'http://www.nature.com:80');
 		});
 
-		it('Should pass the `changeOrigin` flag to the proxy if supplied by the router', function() {
+		it('Should pass the `changeOrigin` flag to the proxy if supplied by the router', function () {
 			var req = {};
 			var res = {};
 			var stub = sinon.stub();
@@ -530,7 +528,7 @@ describe('Request processor', function() {
 			assert.strictEqual(stub.firstCall.args[2].changeOrigin, true);
 		});
 
-		it('Should create an `X-Orig-Host` header if `changeOrigin` is set', function() {
+		it('Should create an `X-Orig-Host` header if `changeOrigin` is set', function () {
 			var req = {
 				headers: {
 					host: 'hostname'
@@ -551,7 +549,7 @@ describe('Request processor', function() {
 			assert.strictEqual(stub.firstCall.args[0].headers['X-Orig-Host'], 'hostname');
 		});
 
-		it('Should return a 404 error if the route isn\'t matched', function() {
+		it('Should return a 404 error if the route isn\'t matched', function () {
 			var req = {};
 			var res = {};
 			var stub = sinon.stub();
@@ -566,7 +564,7 @@ describe('Request processor', function() {
 			assert.strictEqual(dispatch.send.firstCall.args[0].status, 404);
 		});
 
-		it('Should return a 500 error if the route doesn\'t have a host property', function() {
+		it('Should return a 500 error if the route doesn\'t have a host property', function () {
 			var req = {};
 			var res = {};
 			var stub = sinon.stub();
@@ -584,7 +582,7 @@ describe('Request processor', function() {
 			assert.strictEqual(dispatch.send.firstCall.args[0].status, 500);
 		});
 
-		it('Should return a 502 error if the proxy connection fails', function() {
+		it('Should return a 502 error if the proxy connection fails', function () {
 			var req = {};
 			var res = {};
 			var stub = sinon.stub();
@@ -602,7 +600,7 @@ describe('Request processor', function() {
 			assert.strictEqual(dispatch.send.firstCall.args[0].status, 502);
 		});
 
-		it('Should return a 500 error if the proxy fails for any other reason', function() {
+		it('Should return a 500 error if the proxy fails for any other reason', function () {
 			var req = {};
 			var res = {};
 			var stub = sinon.stub();
@@ -618,5 +616,4 @@ describe('Request processor', function() {
 			assert.strictEqual(dispatch.send.firstCall.args[0].status, 500);
 		});
 	});
-	// jscs:enable disallowDanglingUnderscores
 });

--- a/tests/server/core/renderer-whitespace.js
+++ b/tests/server/core/renderer-whitespace.js
@@ -2,6 +2,7 @@
 
 var assert = require('proclaim');
 var sinon = require('sinon');
+
 var mockConfig = {
 	env: {
 		name: 'development'
@@ -26,54 +27,62 @@ var mockConfig = {
 	modules: []
 };
 
-describe('Whitespace Preservation Config', function() {
-	it('preserves whitespace in a compiled template given a config option', function(done) {
+describe('Whitespace Preservation Config', function () {
+	it('preserves whitespace in a compiled template given a config option', function (done) {
 		mockConfig.argv = {
 			'preserve-whitespace': true
 		};
 		var renderer = require('../../../lib/renderer')(mockConfig);
-		// invoke the code that sets dust.mockConfig.whitespace based on our mockConfig
+		// Invoke the code that sets dust.mockConfig.whitespace based on our mockConfig
 		require('../../../lib/dust')(renderer.dust, renderer, mockConfig);
-		// jscs:disable validateQuoteMarks
-		var template = '{#data}{.}  {/data}' + "\n\n"; // jshint ignore:line
+
+		/* eslint-disable no-useless-concat */
+		var template = '{#data}{.}  {/data}' + '\n\n';
 		var callback = sinon.stub();
+
 		renderer.dust.loadSource(renderer.dust.compile(template, 'test-template'));
 		renderer.renderPartial('test-template', {}, {}, {data: ['a', 'b', 'c']}, callback);
-		assert.strictEqual(callback.firstCall.args[1], 'a  b  c  ' + "\n\n"); // jshint ignore:line
-		// jscs:enable validateQuoteMarks
+		assert.strictEqual(callback.firstCall.args[1], 'a  b  c  ' + '\n\n');
+		/* eslint-enable no-useless-concat */
+
 		done();
 	});
 
-	it('does not preserve whitespace in compiled template if preserve-whitespace config option is false', function(done) {
+	it('does not preserve whitespace in compiled template if preserve-whitespace config option is false', function (done) {
 		mockConfig.argv = {
 			'preserve-whitespace': false
 		};
 		var renderer = require('../../../lib/renderer')(mockConfig);
-		// invoke the code that sets dust.mockConfig.whitespace based on our mockConfig
+		// Invoke the code that sets dust.mockConfig.whitespace based on our mockConfig
 		require('../../../lib/dust')(renderer.dust, renderer, mockConfig);
-		// jscs:disable validateQuoteMarks
-		var template = '{#data}{.}  {/data}' + "\n\n"; // jshint ignore:line
+
+		/* eslint-disable no-useless-concat */
+		var template = '{#data}{.}  {/data}' + '\n\n';
 		var callback = sinon.stub();
+
 		renderer.dust.loadSource(renderer.dust.compile(template, 'test-template'));
 		renderer.renderPartial('test-template', {}, {}, {data: ['a', 'b', 'c']}, callback);
-		assert.strictEqual(callback.firstCall.args[1], 'a  b  c  '); // jshint ignore:line
-		// jscs:enable validateQuoteMarks
+		assert.strictEqual(callback.firstCall.args[1], 'a  b  c  ');
+		/* eslint-enable no-useless-concat */
+
 		done();
 	});
 
-
-	it('removes whitespace in a compiled template by default', function(done) {
+	it('removes whitespace in a compiled template by default', function (done) {
 		mockConfig.argv = {};
 		var renderer = require('../../../lib/renderer')(mockConfig);
-		// invoke the code that sets dust.mockConfig.whitespace based on our mockConfig
+		// Invoke the code that sets dust.mockConfig.whitespace based on our mockConfig
 		require('../../../lib/dust')(renderer.dust, renderer, mockConfig);
-		// jscs:disable validateQuoteMarks
-		var template = '{#data}{.}  {/data}' + "\n\n"; // jshint ignore:line
+
+		/* eslint-disable no-useless-concat */
+		var template = '{#data}{.}  {/data}' + '\n\n';
 		var callback = sinon.stub();
+
 		renderer.dust.loadSource(renderer.dust.compile(template, 'test-template'));
 		renderer.renderPartial('test-template', {}, {}, {data: ['a', 'b', 'c']}, callback);
-		assert.strictEqual(callback.firstCall.args[1], 'a  b  c  '); // jshint ignore:line
-		// jscs:enable validateQuoteMarks
+		assert.strictEqual(callback.firstCall.args[1], 'a  b  c  ');
+		/* eslint-disable no-useless-concat */
+
 		done();
 	});
 });

--- a/tests/server/core/renderer.js
+++ b/tests/server/core/renderer.js
@@ -52,12 +52,12 @@ var mockResponse = {};
 
 var RENDERER_MODULE = '../../../lib/renderer';
 
-describe('Renderer', function() {
+describe('Renderer', function () {
 	var watcher;
 	var inputFilter;
 	var config;
 
-	beforeEach(function() {
+	beforeEach(function () {
 		mockery.enable({
 			useCleanCache: true,
 			warnOnUnregistered: false,
@@ -65,8 +65,8 @@ describe('Renderer', function() {
 		});
 
 		config = require('../../../lib/config')('development', null, {});
-		config.timer = function() {
-			return function() {};
+		config.timer = function () {
+			return function () {};
 		};
 
 		watcher = require('../mocks/watcher');
@@ -82,15 +82,15 @@ describe('Renderer', function() {
 		mockery.registerMock('./input-filter', inputFilter);
 	});
 
-	afterEach(function() {
+	afterEach(function () {
 		mockery.deregisterAll();
 		mockery.disable();
 		mockConfig.env.isProduction.returns(true);
 		mockConfig.log.error.reset();
 	});
 
-	describe('Asset handling', function() {
-		it('Should setup the logger for mincer', function() {
+	describe('Asset handling', function () {
+		it('Should setup the logger for mincer', function () {
 			require('fs').readdirSync.returns([]);
 
 			var mincer = require('mincer');
@@ -100,7 +100,7 @@ describe('Renderer', function() {
 			assert.isTrue(mincer.logger.use.calledOnce);
 		});
 
-		it('Should setup mincer extensions', function() {
+		it('Should setup mincer extensions', function () {
 			require('path').join.returnsArg(1);
 			var initMincerExtension = sinon.stub();
 			var eachModule = require('each-module');
@@ -113,7 +113,7 @@ describe('Renderer', function() {
 			assert.isTrue(initMincerExtension.calledWith(mincer, mockConfig));
 		});
 
-		it('Should skip mincer extensions that do not expose a function', function() {
+		it('Should skip mincer extensions that do not expose a function', function () {
 			require('path').join.returnsArg(1);
 			var initMincerExtension = sinon.stub();
 			var eachModule = require('each-module');
@@ -125,12 +125,12 @@ describe('Renderer', function() {
 			assert.strictEqual(initMincerExtension.callCount, 2);
 		});
 
-		it('Should setup the `asset_path` ejs helper', function() {
+		it('Should setup the `asset_path` ejs helper', function () {
 			var renderer = require(RENDERER_MODULE)(mockConfig);
 			assert.strictEqual(renderer.environment.registerHelper.withArgs('asset_path').callCount, 1);
 		});
 
-		it('Should setup additional ejs helpers', function() {
+		it('Should setup additional ejs helpers', function () {
 			require('path').join.returnsArg(1);
 			var helper = sinon.stub();
 			var eachModule = require('each-module');
@@ -142,7 +142,7 @@ describe('Renderer', function() {
 			assert.isTrue(helper.calledWith(renderer.environment, renderer.manifest, mockConfig));
 		});
 
-		it('Should skip ejs helpers that do not expose a function', function() {
+		it('Should skip ejs helpers that do not expose a function', function () {
 			require('path').join.returnsArg(1);
 			var helper = sinon.stub();
 			var eachModule = require('each-module');
@@ -154,7 +154,7 @@ describe('Renderer', function() {
 			assert.strictEqual(helper.callCount, 2);
 		});
 
-		it('Should setup input filters', function() {
+		it('Should setup input filters', function () {
 			require('path').join.returnsArg(1);
 			var filter = sinon.stub();
 			var eachModule = require('each-module');
@@ -164,7 +164,7 @@ describe('Renderer', function() {
 			assert.strictEqual(inputFilter().add.withArgs(filter).callCount, 3);
 		});
 
-		it('Should skip input filters that do not expose a function', function() {
+		it('Should skip input filters that do not expose a function', function () {
 			require('path').join.returnsArg(1);
 			var filter = sinon.stub();
 			var eachModule = require('each-module');
@@ -175,7 +175,7 @@ describe('Renderer', function() {
 			assert.strictEqual(inputFilter().add.withArgs(filter).callCount, 2);
 		});
 
-		// it('Should configure the asset paths in the correct order', function() {
+		// It('Should configure the asset paths in the correct order', function() {
 		// 	require('fs').readdirSync.returns([]);
 		// 	require('fs').existsSync.returns(true);
 		// 	require('path').join.returnsArg(1);
@@ -192,7 +192,7 @@ describe('Renderer', function() {
 		// similar tests when we rewrite the asset loading logic for the new application structure
 		//
 
-		it('Should append the asset paths for the host app, in the correct order (i.e. on odd iterations)', function() {
+		it('Should append the asset paths for the host app, in the correct order (i.e. on odd iterations)', function () {
 			require('fs').existsSync.returns(true);
 			require('fs').mockStatReturn.isDirectory.returns(true);
 			require('path').join.returnsArg(1);
@@ -205,7 +205,7 @@ describe('Renderer', function() {
 			assert.isTrue(renderer.environment.appendPath.getCall(6).calledWith('js'));
 		});
 
-		it('Should configure the asset paths for the modules after the host app ones, in the correct order (i.e. on even iterations)', function() {
+		it('Should configure the asset paths for the modules after the host app ones, in the correct order (i.e. on even iterations)', function () {
 			require('fs').existsSync.returns(true);
 			require('fs').mockStatReturn.isDirectory.returns(true);
 			require('path').join.returnsArg(2);
@@ -218,7 +218,7 @@ describe('Renderer', function() {
 			assert.isTrue(renderer.environment.appendPath.getCall(7).calledWith('js'));
 		});
 
-		it('Should not configure asset paths for files in a module that is not explicitly included', function() {
+		it('Should not configure asset paths for files in a module that is not explicitly included', function () {
 			var tempConfigModules = mockConfig.modules;
 			mockConfig.modules = [];
 			require('fs').existsSync.returns(true);
@@ -230,7 +230,7 @@ describe('Renderer', function() {
 			mockConfig.modules = tempConfigModules;
 		});
 
-		it('Should create an asset server for the environment', function() {
+		it('Should create an asset server for the environment', function () {
 			require('fs').readdirSync.returns([]);
 
 			var mincer = require('mincer');
@@ -242,7 +242,7 @@ describe('Renderer', function() {
 			assert.isTrue(mincer.createServer.calledWith(renderer.environment));
 		});
 
-		it('Should return an asset from the environment in dev mode', function() {
+		it('Should return an asset from the environment in dev mode', function () {
 			require('fs').readdirSync.returns([]);
 			mockConfig.env.isProduction.returns(false);
 
@@ -257,7 +257,7 @@ describe('Renderer', function() {
 			assert.strictEqual(asset, 'test-env-md5.css');
 		});
 
-		it('Should return an asset from the manifest in production mode', function() {
+		it('Should return an asset from the manifest in production mode', function () {
 			require('fs').readdirSync.returns([]);
 
 			var renderer = require(RENDERER_MODULE)(mockConfig);
@@ -268,7 +268,7 @@ describe('Renderer', function() {
 			assert.strictEqual(asset, 'test-prod-md5.css');
 		});
 
-		it('Should return an empty string if the asset isn\'t found', function() {
+		it('Should return an empty string if the asset isn\'t found', function () {
 			require('fs').readdirSync.returns([]);
 
 			var renderer = require(RENDERER_MODULE)(mockConfig);
@@ -280,8 +280,8 @@ describe('Renderer', function() {
 		});
 	});
 
-	describe('Template compilation', function() {
-		it('Should watch the templates directories', function() {
+	describe('Template compilation', function () {
+		it('Should watch the templates directories', function () {
 			require('fs').readdirSync.returns([]);
 			require('path').join.returns('/module/view');
 			var renderer = require(RENDERER_MODULE)(mockConfig);
@@ -293,7 +293,7 @@ describe('Renderer', function() {
 			assert.isTrue(watcher().watchTree().on.calledWith('fileCreated'));
 		});
 
-		it('Should create cached compiled templates with namespaced key ids', function() {
+		it('Should create cached compiled templates with namespaced key ids', function () {
 			require('fs').readdirSync.returns([]);
 
 			var renderer = require(RENDERER_MODULE)(mockConfig);
@@ -314,7 +314,7 @@ describe('Renderer', function() {
 			assert.strictEqual(renderer.dust.loadSource.firstCall.args[0], 'compiled');
 		});
 
-		it('Should gracefully handle dust compilation errors', function() {
+		it('Should gracefully handle dust compilation errors', function () {
 			require('fs').readdirSync.returns([]);
 
 			var renderer = require(RENDERER_MODULE)(mockConfig);
@@ -325,7 +325,7 @@ describe('Renderer', function() {
 			require('path').relative.returns('foo/bar/foo.dust');
 			renderer.dust.compile.withArgs('invalid content').throws({message: 'FAILED'});
 
-			assert.doesNotThrow(function() {
+			assert.doesNotThrow(function () {
 				renderer.compileFile('foo/bar/foo.dust');
 			});
 			assert.isTrue(mockConfig.log.error.calledOnce);
@@ -333,7 +333,7 @@ describe('Renderer', function() {
 			assert.include(mockConfig.log.error.firstCall.args[0], 'foo/bar/foo.dust');
 		});
 
-		it('Removes the \'/view/\' part of the path and anything before', function() {
+		it('Removes the \'/view/\' part of the path and anything before', function () {
 			require('fs').readdirSync.returns([]);
 
 			var renderer = require(RENDERER_MODULE)(mockConfig);
@@ -349,7 +349,7 @@ describe('Renderer', function() {
 		});
 
 		// DEPRECATED: handling '..'from relative as /view still exists while transferring to themes
-		it('Removes the \'/view/\' part of the path (DEPRECATED)', function() {
+		it('Removes the \'/view/\' part of the path (DEPRECATED)', function () {
 			require('fs').readdirSync.returns([]);
 
 			var renderer = require(RENDERER_MODULE)(mockConfig);
@@ -364,7 +364,7 @@ describe('Renderer', function() {
 			assert.equal(renderer.dust.compile.firstCall.args[1], 'root__foo');
 		});
 
-		it('Should recompile templates when a file changes', function() {
+		it('Should recompile templates when a file changes', function () {
 			require('fs').readdirSync.returns([]);
 
 			var renderer = require(RENDERER_MODULE)(mockConfig);
@@ -382,7 +382,7 @@ describe('Renderer', function() {
 			renderer.compileFile.restore();
 		});
 
-		it('Should compile an array of file paths', function() {
+		it('Should compile an array of file paths', function () {
 			require('fs').readdirSync.returns([]);
 
 			var renderer = require(RENDERER_MODULE)(mockConfig);
@@ -403,7 +403,7 @@ describe('Renderer', function() {
 			assert.isTrue(renderer.dust.loadSource.calledWith('compiled'));
 		});
 
-		it('Should compile file paths as an argument list', function() {
+		it('Should compile file paths as an argument list', function () {
 			require('fs').readdirSync.returns([]);
 
 			var renderer = require(RENDERER_MODULE)(mockConfig);
@@ -424,7 +424,7 @@ describe('Renderer', function() {
 			assert.isTrue(renderer.dust.loadSource.calledWith('compiled'));
 		});
 
-		it('Should not compile anything without a .dust extension', function() {
+		it('Should not compile anything without a .dust extension', function () {
 			require('fs').readdirSync.returns([]);
 
 			var renderer = require(RENDERER_MODULE)(mockConfig);
@@ -440,7 +440,7 @@ describe('Renderer', function() {
 			assert.strictEqual(renderer.dust.loadSource.callCount, 0);
 		});
 
-		it('Should select all dust files from a configured theme directory\'s subfolders', function() {
+		it('Should select all dust files from a configured theme directory\'s subfolders', function () {
 			require('fs').readdirSync.returns([]);
 			var renderer = require(RENDERER_MODULE)(mockConfig);
 			var gsync = require('glob').sync.returns(['filepath']);
@@ -452,7 +452,7 @@ describe('Renderer', function() {
 			assert.isTrue(renderer.compileFileList.calledWith(['filepath', 'filepath']));
 		});
 
-		it('Should compile each file from a list of files', function() {
+		it('Should compile each file from a list of files', function () {
 			require('fs').readdirSync.returns([]);
 
 			var renderer = require(RENDERER_MODULE)(mockConfig);
@@ -468,8 +468,8 @@ describe('Renderer', function() {
 		});
 	});
 
-	describe('Dust extension loading', function() {
-		it('Should watch the dust directories', function() {
+	describe('Dust extension loading', function () {
+		it('Should watch the dust directories', function () {
 			require('fs').readdirSync.returns([]);
 			require('path').join.returns('/module/dust');
 			var renderer = require(RENDERER_MODULE)(mockConfig);
@@ -482,8 +482,8 @@ describe('Renderer', function() {
 		});
 	});
 
-	describe('Rendering', function() {
-		it('Should default to rendering the layout template unless one is specified', function() {
+	describe('Rendering', function () {
+		it('Should default to rendering the layout template unless one is specified', function () {
 			require('fs').readdirSync.returns([]);
 
 			var renderer = require(RENDERER_MODULE)(mockConfig);
@@ -491,14 +491,14 @@ describe('Renderer', function() {
 			sinon.stub(renderer, 'renderPartial');
 			renderer.render(mockRequest, mockResponse, {
 				foo: 'bar'
-			}, function() { });
+			}, function () { });
 
 			assert.isTrue(renderer.renderPartial.calledWith('layout'));
 
 			renderer.renderPartial.restore();
 		});
 
-		it('Should select a layout template from the data', function() {
+		it('Should select a layout template from the data', function () {
 			require('fs').readdirSync.returns([]);
 
 			var renderer = require(RENDERER_MODULE)(mockConfig);
@@ -508,14 +508,14 @@ describe('Renderer', function() {
 				layout: {
 					template: 'test-layout'
 				}
-			}, function() { });
+			}, function () { });
 
 			assert.isTrue(renderer.renderPartial.calledWith('test-layout'));
 
 			renderer.renderPartial.restore();
 		});
 
-		it('Should render a dust template after applying filters', function() {
+		it('Should render a dust template after applying filters', function () {
 			require('fs').readdirSync.returns([]);
 
 			var renderer = require(RENDERER_MODULE)(mockConfig);

--- a/tests/server/core/router.js
+++ b/tests/server/core/router.js
@@ -5,8 +5,8 @@ var assert = require('proclaim');
 var moduleName = '../../../lib/router';
 var config;
 
-describe('Proxy routing', function() {
-	beforeEach(function() {
+describe('Proxy routing', function () {
+	beforeEach(function () {
 		config = {};
 		config.routes = {
 			localhost: {
@@ -38,11 +38,11 @@ describe('Proxy routing', function() {
 		config.log = require('../mocks/log');
 	});
 
-	afterEach(function() {
+	afterEach(function () {
 		config = {};
 	});
 
-	it('Should create a routes object from config objects\'s contents', function() {
+	it('Should create a routes object from config objects\'s contents', function () {
 		config.routes = {
 			localhost: {
 				'/foo/': 'bar'
@@ -53,7 +53,7 @@ describe('Proxy routing', function() {
 		assert.equal(route1, 'bar');
 	});
 
-	it('Should get the route from the given host if possible', function() {
+	it('Should get the route from the given host if possible', function () {
 		config.routes = {
 			'www.nature.com': {
 				'/foo/': 'success'
@@ -67,7 +67,7 @@ describe('Proxy routing', function() {
 		assert.equal(route1, 'success');
 	});
 
-	it('Should ignore the port 80', function() {
+	it('Should ignore the port 80', function () {
 		config.routes = {
 			'www.nature.com': {
 				'/foo/': 'success'
@@ -81,7 +81,7 @@ describe('Proxy routing', function() {
 		assert.equal(route1, 'success');
 	});
 
-	it('Should fallback to localhost if the host doesn\'t match', function() {
+	it('Should fallback to localhost if the host doesn\'t match', function () {
 		config.routes = {
 			'www.nature.com': {
 				'/foo/': 'fail'
@@ -95,7 +95,7 @@ describe('Proxy routing', function() {
 		assert.equal(route1, 'success');
 	});
 
-	it('Should return null if the host doesn\'t match and no localhost routes are defined', function() {
+	it('Should return null if the host doesn\'t match and no localhost routes are defined', function () {
 		config.routes = {
 			'www.nature.com': {
 				'/foo/': 'fail'
@@ -106,7 +106,7 @@ describe('Proxy routing', function() {
 		assert.isNull(route);
 	});
 
-	it('Should map a url to the first matched rule', function() {
+	it('Should map a url to the first matched rule', function () {
 		var router = require(moduleName)(config);
 		var route1 = router.map('localhost', '/test/foo');
 		assert.equal(route1.host, 'test-www.nature.com');
@@ -116,13 +116,13 @@ describe('Proxy routing', function() {
 		assert.equal(route2.port, 82);
 	});
 
-	it('Should map a url that doesn\'t match any of the rules to the default', function() {
+	it('Should map a url that doesn\'t match any of the rules to the default', function () {
 		var route = require(moduleName)(config).map('localhost', '/');
 		assert.equal(route.host, '127.0.0.1');
 		assert.equal(route.port, 5410);
 	});
 
-	it('Should allow the default route to be configured', function() {
+	it('Should allow the default route to be configured', function () {
 		config.argv = {
 			'route-config': 'capybara'
 		};
@@ -131,9 +131,8 @@ describe('Proxy routing', function() {
 		assert.equal(route.port, 22789);
 	});
 
-	describe('Should set the default route from that specified in the config options', function() {
-
-		it('Should set a route with a protocol, hostname and port', function() {
+	describe('Should set the default route from that specified in the config options', function () {
+		it('Should set a route with a protocol, hostname and port', function () {
 			config.argv = {
 				'route-override': 'https://foo.dev.bar-baz.com:80'
 			};
@@ -143,7 +142,7 @@ describe('Proxy routing', function() {
 			assert.equal(route.port, 80);
 		});
 
-		it('Should set a route with an IPv4 address and port, defaulting the protocol to http', function() {
+		it('Should set a route with an IPv4 address and port, defaulting the protocol to http', function () {
 			config.argv = {
 				'route-override': '127.0.0.1:9000'
 			};
@@ -153,7 +152,7 @@ describe('Proxy routing', function() {
 			assert.equal(route.port, 9000);
 		});
 
-		it('Should set a route with a hostname defaulting the protocol to http', function() {
+		it('Should set a route with a hostname defaulting the protocol to http', function () {
 			config.argv = {
 				'route-override': 'localhost'
 			};
@@ -162,10 +161,9 @@ describe('Proxy routing', function() {
 			assert.equal(route.host, 'localhost');
 			assert.equal(route.port, null);
 		});
-
 	});
 
-	it('Should set the default route and changeOrigin state if specified in the config options', function() {
+	it('Should set the default route and changeOrigin state if specified in the config options', function () {
 		config.argv = {
 			'route-override': '127.0.0.1:9000',
 			'origin-override': true
@@ -176,7 +174,7 @@ describe('Proxy routing', function() {
 		assert.equal(route.changeOrigin, true);
 	});
 
-	it('Should not match a named route against the url', function() {
+	it('Should not match a named route against the url', function () {
 		var route = require(moduleName)(config).map('localhost', '/capybara');
 		assert.equal(route.host, '127.0.0.1');
 		assert.equal(route.port, 5410);

--- a/tests/server/core/server.js
+++ b/tests/server/core/server.js
@@ -4,7 +4,7 @@ var assert = require('proclaim');
 var sinon = require('sinon');
 var mockery = require('mockery');
 
-describe('Clustering', function() {
+describe('Clustering', function () {
 	var worker;
 	var server;
 	var cluster;
@@ -12,7 +12,7 @@ describe('Clustering', function() {
 	var timers;
 	var config;
 
-	beforeEach(function() {
+	beforeEach(function () {
 		config = {
 			path: {
 				root: '/'
@@ -46,7 +46,7 @@ describe('Clustering', function() {
 		sinon.stub(process, 'on');
 		sinon.stub(process, 'exit');
 	});
-	afterEach(function() {
+	afterEach(function () {
 		mockery.deregisterAll();
 		mockery.disable();
 		process.on.restore();
@@ -54,27 +54,27 @@ describe('Clustering', function() {
 		timers.restore();
 	});
 
-	describe('Master', function() {
-		it('Should create the right number of forks lower than max-child-processes', function() {
+	describe('Master', function () {
+		it('Should create the right number of forks lower than max-child-processes', function () {
 			require('os').cpus.returns([1, 1, 1]);
 			server.start();
 			assert.equal(cluster.fork.callCount, 3);
 		});
 
-		it('Should create the right number of forks no more than max-child-processes', function() {
+		it('Should create the right number of forks no more than max-child-processes', function () {
 			require('os').cpus.returns([1, 1, 1, 1, 1, 1]);
 			server.start();
 			assert.equal(cluster.fork.callCount, 5);
 		});
 
-		it('Should log a message when all child processes have been created', function() {
+		it('Should log a message when all child processes have been created', function () {
 			require('os').cpus.returns([1, 1]);
 			server.start();
 			cluster.fork().on.yield();
 			assert.isTrue(config.log.info.calledWith('Shunter started with 2 child processes listening'));
 		});
 
-		it('Should save the a pid file on start up', function() {
+		it('Should save the a pid file on start up', function () {
 			require('os').cpus.returns([1, 1, 1]);
 			require('path').join.returns('/shunter.pid');
 			server.start();
@@ -83,7 +83,7 @@ describe('Clustering', function() {
 			assert.isTrue(config.log.debug.calledWith('Saved shunter.pid file for process ' + process.pid));
 		});
 
-		it('Should log an error if it was unable to write the pid file', function() {
+		it('Should log an error if it was unable to write the pid file', function () {
 			require('os').cpus.returns([1, 1, 1]);
 			require('path').join.returns('/shunter.pid');
 			server.start();
@@ -92,27 +92,27 @@ describe('Clustering', function() {
 			assert.isTrue(config.log.error.calledWith('Error saving shunter.pid file for process ' + process.pid + ' ERROR'));
 		});
 
-		it('Should save the current timestamp as json', function() {
+		it('Should save the current timestamp as json', function () {
 			require('os').cpus.returns([1, 1, 1]);
 			require('path').join.returns('/timestamp.json');
 			server.start();
 			assert.isTrue(fs.writeFileSync.calledWith('/timestamp.json', '{"value":10}'));
 		});
 
-		it('Should setup the SIGUSR2 handler', function() {
+		it('Should setup the SIGUSR2 handler', function () {
 			require('os').cpus.returns([1, 1, 1]);
 			server.start();
 			assert.isTrue(process.on.calledWith('SIGUSR2'));
 		});
 
-		it('Should log a message when SIGUSR2 is captured', function() {
+		it('Should log a message when SIGUSR2 is captured', function () {
 			require('os').cpus.returns([1, 1, 1]);
 			server.start();
 			process.on.withArgs('SIGUSR2').firstCall.yield();
 			assert.isTrue(config.log.debug.calledWith('SIGUSR2 received, reloading all workers'));
 		});
 
-		it('Should save the timestamp when SIGUSR2 is captured', function() {
+		it('Should save the timestamp when SIGUSR2 is captured', function () {
 			require('os').cpus.returns([1, 1, 1]);
 			require('path').join.returns('/timestamp.json');
 			server.start();
@@ -120,8 +120,8 @@ describe('Clustering', function() {
 			assert.isTrue(fs.writeFileSync.calledWith('/timestamp.json', '{"value":10}'));
 		});
 
-		it('Should reload all worker processes when SIGUSR2 is captured', function() {
-			var oldWorkers = [1234, 1235].map(function(pid) {
+		it('Should reload all worker processes when SIGUSR2 is captured', function () {
+			var oldWorkers = [1234, 1235].map(function (pid) {
 				return {
 					process: {
 						pid: pid
@@ -130,7 +130,7 @@ describe('Clustering', function() {
 					disconnect: sinon.stub()
 				};
 			});
-			var newWorkers = [1236, 1237].map(function(pid) {
+			var newWorkers = [1236, 1237].map(function (pid) {
 				return {
 					process: {
 						pid: pid
@@ -140,7 +140,7 @@ describe('Clustering', function() {
 				};
 			});
 
-			oldWorkers.forEach(function(worker, i) {
+			oldWorkers.forEach(function (worker, i) {
 				cluster.workers[i] = worker;
 				cluster.fork.onCall(i + 2).returns(newWorkers[i]);
 			});
@@ -167,7 +167,7 @@ describe('Clustering', function() {
 			assert.isTrue(config.log.info.calledWith('All replacement workers now running'));
 		});
 
-		it('Should log a message when the old workers are disconnected', function() {
+		it('Should log a message when the old workers are disconnected', function () {
 			cluster.workers[0] = {
 				process: {
 					pid: '2345'
@@ -184,7 +184,7 @@ describe('Clustering', function() {
 			assert.isTrue(config.log.info.calledWith('Shutdown complete for 2345'));
 		});
 
-		it('Should force a worker to shutdown if it doesn\'t disconnect within 10 seconds', function() {
+		it('Should force a worker to shutdown if it doesn\'t disconnect within 10 seconds', function () {
 			cluster.workers[0] = {
 				process: {
 					pid: '2345'
@@ -204,26 +204,26 @@ describe('Clustering', function() {
 			assert.isTrue(cluster.workers[0].send.calledWith('force exit'));
 		});
 
-		it('Should setup the SIGINT handler', function() {
+		it('Should setup the SIGINT handler', function () {
 			require('os').cpus.returns([1, 1, 1]);
 			server.start();
 			assert.isTrue(process.on.calledWith('SIGINT'));
 		});
 
-		it('Should exit the process cleanly when SIGINT is captured', function() {
+		it('Should exit the process cleanly when SIGINT is captured', function () {
 			require('os').cpus.returns([1, 1, 1]);
 			server.start();
 			process.on.withArgs('SIGINT').firstCall.yield();
 			assert.isTrue(process.exit.calledWith(0));
 		});
 
-		it('Should setup the exit handler', function() {
+		it('Should setup the exit handler', function () {
 			require('os').cpus.returns([1, 1, 1]);
 			server.start();
 			assert.isTrue(process.on.calledWith('exit'));
 		});
 
-		it('Should delete the pid file when process.exit is fired', function() {
+		it('Should delete the pid file when process.exit is fired', function () {
 			require('os').cpus.returns([1, 1, 1]);
 			require('path').join.returns('/shunter.pid');
 			server.start();
@@ -231,14 +231,14 @@ describe('Clustering', function() {
 			assert.isTrue(fs.unlinkSync.calledWith('/shunter.pid'));
 		});
 
-		it('Should listen for the exit event', function() {
+		it('Should listen for the exit event', function () {
 			require('os').cpus.returns([1, 1, 1]);
 			server.start();
 			assert.isTrue(cluster.on.calledOnce);
 			assert.isTrue(cluster.on.calledWith('exit'));
 		});
 
-		it('Should create a new fork on exit', function() {
+		it('Should create a new fork on exit', function () {
 			require('os').cpus.returns([1]);
 			server.start();
 			assert.equal(cluster.fork.callCount, 1);
@@ -246,7 +246,7 @@ describe('Clustering', function() {
 			assert.equal(cluster.fork.callCount, 2);
 		});
 
-		it('Should not create a new fork on exit if the worker was exited intentionally', function() {
+		it('Should not create a new fork on exit if the worker was exited intentionally', function () {
 			require('os').cpus.returns([1]);
 			server.start();
 			assert.equal(cluster.fork.callCount, 1);
@@ -255,8 +255,8 @@ describe('Clustering', function() {
 		});
 	});
 
-	describe('Worker', function() {
-		it('Should call worker with the config', function() {
+	describe('Worker', function () {
+		it('Should call worker with the config', function () {
 			cluster.isMaster = false;
 			server.start();
 			assert.isTrue(worker.calledOnce);
@@ -264,14 +264,14 @@ describe('Clustering', function() {
 		});
 	});
 
-	describe('Middleware', function() {
-		it('Should expose a `use` method', function() {
+	describe('Middleware', function () {
+		it('Should expose a `use` method', function () {
 			assert.isFunction(server.use);
 		});
 
-		it('Should add the arguments passed into `use` to the middleware config', function() {
-			var fn1 = function() {};
-			var fn2 = function() {};
+		it('Should add the arguments passed into `use` to the middleware config', function () {
+			var fn1 = function () {};
+			var fn2 = function () {};
 			server.use('foo', fn1);
 			server.use(fn2);
 			assert.lengthEquals(config.middleware, 2);

--- a/tests/server/core/statsd.js
+++ b/tests/server/core/statsd.js
@@ -4,14 +4,14 @@
 var assert = require('proclaim');
 var sinon = require('sinon');
 var mockery = require('mockery');
-var modulePath = '../../../lib/statsd';
 
+var modulePath = '../../../lib/statsd';
 var mockConfig;
 
-describe('Logging to statsd', function() {
+describe('Logging to statsd', function () {
 	var client;
 
-	beforeEach(function() {
+	beforeEach(function () {
 		mockConfig = {
 			statsd: {
 				mappings: [
@@ -53,56 +53,56 @@ describe('Logging to statsd', function() {
 
 		mockery.registerMock('statsd-client', sinon.stub().returns(client));
 	});
-	afterEach(function() {
+	afterEach(function () {
 		mockery.deregisterAll();
 		mockery.disable();
 		mockConfig.log.error.reset();
 	});
 
-	describe('Native methods', function() {
-		it('Should proxy `increment` calls to the statsd client', function() {
+	describe('Native methods', function () {
+		it('Should proxy `increment` calls to the statsd client', function () {
 			var statsd = require(modulePath)(mockConfig);
 			statsd.increment('foo');
 			assert.isTrue(client.increment.calledOnce);
 			assert.isTrue(client.increment.calledWith('foo'));
 		});
 
-		it('Should proxy `decrement` calls to the statsd client', function() {
+		it('Should proxy `decrement` calls to the statsd client', function () {
 			var statsd = require(modulePath)(mockConfig);
 			statsd.decrement('foo');
 			assert.isTrue(client.decrement.calledOnce);
 			assert.isTrue(client.decrement.calledWith('foo'));
 		});
 
-		it('Should proxy `timing` calls to the statsd client', function() {
+		it('Should proxy `timing` calls to the statsd client', function () {
 			var statsd = require(modulePath)(mockConfig);
 			statsd.timing('foo', 1);
 			assert.isTrue(client.timing.calledOnce);
 			assert.isTrue(client.timing.calledWith('foo', 1));
 		});
 
-		it('Should proxy `gauge` calls to the statsd client', function() {
+		it('Should proxy `gauge` calls to the statsd client', function () {
 			var statsd = require(modulePath)(mockConfig);
 			statsd.gauge('foo', 1, 0.25);
 			assert.isTrue(client.gauge.calledOnce);
 			assert.isTrue(client.gauge.calledWith('foo', 1, 0.25));
 		});
 
-		it('Should proxy `gaugeDelta` calls to the statsd client', function() {
+		it('Should proxy `gaugeDelta` calls to the statsd client', function () {
 			var statsd = require(modulePath)(mockConfig);
 			statsd.gaugeDelta('foo', 1);
 			assert.isTrue(client.gaugeDelta.calledOnce);
 			assert.isTrue(client.gaugeDelta.calledWith('foo', 1));
 		});
 
-		it('Should proxy `histogram` calls to the statsd client', function() {
+		it('Should proxy `histogram` calls to the statsd client', function () {
 			var statsd = require(modulePath)(mockConfig);
 			statsd.histogram('foo', 1);
 			assert.isTrue(client.histogram.calledOnce);
 			assert.isTrue(client.histogram.calledWith('foo', 1));
 		});
 
-		it('Should proxy `set` calls to the statsd client', function() {
+		it('Should proxy `set` calls to the statsd client', function () {
 			var statsd = require(modulePath)(mockConfig);
 			statsd.set('foo', 1);
 			assert.isTrue(client.set.calledOnce);
@@ -110,50 +110,50 @@ describe('Logging to statsd', function() {
 		});
 	});
 
-	describe('Extended methods', function() {
-		it('Should pass calls for `classifiedIncrement` to `increment`', function() {
+	describe('Extended methods', function () {
+		it('Should pass calls for `classifiedIncrement` to `increment`', function () {
 			var statsd = require(modulePath)(mockConfig);
 			statsd.classifiedIncrement('/test', 'foo');
 			assert.isTrue(client.increment.calledOnce);
 			assert.isTrue(client.increment.calledWith('foo_test'));
 		});
 
-		it('Should pass calls for `classifiedDecrement` to `decrement`', function() {
+		it('Should pass calls for `classifiedDecrement` to `decrement`', function () {
 			var statsd = require(modulePath)(mockConfig);
 			statsd.classifiedDecrement('/test', 'foo');
 			assert.isTrue(client.decrement.calledOnce);
 			assert.isTrue(client.decrement.calledWith('foo_test'));
 		});
 
-		it('Should pass calls for `classifiedTiming` to `timing`', function() {
+		it('Should pass calls for `classifiedTiming` to `timing`', function () {
 			var statsd = require(modulePath)(mockConfig);
 			statsd.classifiedTiming('/test', 'foo', 10);
 			assert.isTrue(client.timing.calledOnce);
 			assert.isTrue(client.timing.calledWith('foo_test', 10));
 		});
 
-		it('Should pass calls for `classifiedGauge` to `gauge`', function() {
+		it('Should pass calls for `classifiedGauge` to `gauge`', function () {
 			var statsd = require(modulePath)(mockConfig);
 			statsd.classifiedGauge('/test', 'foo', 1);
 			assert.isTrue(client.gauge.calledOnce);
 			assert.isTrue(client.gauge.calledWith('foo_test', 1));
 		});
 
-		it('Should pass calls for `classifiedGaugeDelta` to `gaugeDelta`', function() {
+		it('Should pass calls for `classifiedGaugeDelta` to `gaugeDelta`', function () {
 			var statsd = require(modulePath)(mockConfig);
 			statsd.classifiedGaugeDelta('/test', 'foo', 1);
 			assert.isTrue(client.gaugeDelta.calledOnce);
 			assert.isTrue(client.gaugeDelta.calledWith('foo_test', 1));
 		});
 
-		it('Should pass calls for `classifiedHistogram` to `histogram`', function() {
+		it('Should pass calls for `classifiedHistogram` to `histogram`', function () {
 			var statsd = require(modulePath)(mockConfig);
 			statsd.classifiedHistogram('/test', 'foo', 10);
 			assert.isTrue(client.histogram.calledOnce);
 			assert.isTrue(client.histogram.calledWith('foo_test', 10));
 		});
 
-		it('Should pass calls for `classifiedSet` to `set`', function() {
+		it('Should pass calls for `classifiedSet` to `set`', function () {
 			var statsd = require(modulePath)(mockConfig);
 			statsd.classifiedSet('/test', 'foo', 10);
 			assert.isTrue(client.set.calledOnce);
@@ -161,8 +161,8 @@ describe('Logging to statsd', function() {
 		});
 	});
 
-	describe('Classifying metrics', function() {
-		it('Should classify the metric based on the first config mapping that matches the url', function() {
+	describe('Classifying metrics', function () {
+		it('Should classify the metric based on the first config mapping that matches the url', function () {
 			var statsd = require(modulePath)(mockConfig);
 			statsd.classifiedIncrement('/foo', 'a');
 			assert.isTrue(client.increment.calledWith('a_foo'));
@@ -172,21 +172,21 @@ describe('Logging to statsd', function() {
 			assert.isTrue(client.increment.calledWith('a_foo'));
 		});
 
-		it('Should just use the metric name if the url does not match any of the mappings', function() {
+		it('Should just use the metric name if the url does not match any of the mappings', function () {
 			var statsd = require(modulePath)(mockConfig);
 			statsd.classifiedIncrement('/bar', 'a');
 			assert.isTrue(client.increment.calledWith('a'));
 		});
 
-		it('Should just use the metric name if no mappings are defined', function() {
+		it('Should just use the metric name if no mappings are defined', function () {
 			var statsd = require(modulePath)({statsd: {mock: false}});
 			statsd.classifiedIncrement('/foo', 'a');
 			assert.isTrue(client.increment.calledWith('a'));
 		});
 	});
 
-	describe('Mocking statsd', function() {
-		it('Should not proxy calls to the statsd client when mocked', function() {
+	describe('Mocking statsd', function () {
+		it('Should not proxy calls to the statsd client when mocked', function () {
 			mockConfig.statsd.mock = true;
 
 			var statsd = require(modulePath)(mockConfig);

--- a/tests/server/core/watcher.js
+++ b/tests/server/core/watcher.js
@@ -6,12 +6,12 @@ var sinon = require('sinon');
 
 var moduleName = '../../../lib/watcher';
 
-describe('Watcher watchTree', function() {
+describe('Watcher watchTree', function () {
 	var watchTree;
 	var gaze;
 	var Gaze;
 
-	beforeEach(function() {
+	beforeEach(function () {
 		var watcherMod;
 		mockery.enable({
 			useCleanCache: true,
@@ -22,52 +22,51 @@ describe('Watcher watchTree', function() {
 		watchTree = watcherMod.watchTree;
 	});
 
-	afterEach(function() {
+	afterEach(function () {
 		mockery.deregisterAll();
 		mockery.disable();
 	});
 
-	describe('Gaze setup', function() {
-		beforeEach(function() {
+	describe('Gaze setup', function () {
+		beforeEach(function () {
 			Gaze = sinon.spy();
 			Gaze.prototype.on = sinon.spy();
 			Gaze.prototype.emit = sinon.spy();
 			mockery.registerMock('gaze', Gaze);
 			gaze = require('gaze');
 		});
-		it('Should be a function', function() {
+		it('Should be a function', function () {
 			assert.isFunction(watchTree);
 		});
-		it('Should return an instance of gaze', function() {
+		it('Should return an instance of gaze', function () {
 			var wt = watchTree([], require('../mocks/log'));
 			assert.isTrue(gaze.calledWithNew());
 			assert.instanceOf(wt, gaze);
 		});
-		it('Should create a watcher with the given directory, globbed for dust templates', function() {
+		it('Should create a watcher with the given directory, globbed for dust templates', function () {
 			watchTree('foo', require('../mocks/log'));
 			assert.isTrue(gaze.withArgs('foo/**/*.dust').calledOnce);
 		});
-		it('Should create a watcher with more than one directory', function() {
+		it('Should create a watcher with more than one directory', function () {
 			watchTree(['foo', 'bar'], require('../mocks/log'));
 			assert.isTrue(gaze.withArgs(['foo/**/*.dust', 'bar/**/*.dust']).calledOnce);
 		});
 	});
 
-	describe('Watched Events', function() {
+	describe('Watched Events', function () {
 		var emitSpy;
 		var wt;
-		beforeEach(function() {
+		beforeEach(function () {
 			wt = watchTree('foo', require('../mocks/log'));
 			emitSpy = sinon.spy(wt, 'emit');
 		});
-		it('Should emit a fileCreated event when a file is created', function() {
+		it('Should emit a fileCreated event when a file is created', function () {
 			wt.emit('added', 'foopath');
 			assert(emitSpy.calledWith('fileCreated', 'foopath'));
 		});
-		it('Should emit a fileModified event when a file is modified', function() {
+		it('Should emit a fileModified event when a file is modified', function () {
 			wt.emit('changed', 'barpath');
 			assert(emitSpy.calledWith('fileModified', 'barpath'));
-
 		});
 	});
 });

--- a/tests/server/dust/amp.js
+++ b/tests/server/dust/amp.js
@@ -4,12 +4,12 @@
 var assert = require('proclaim');
 var helper = require('../../helpers/template.js')();
 
-describe('Dust Filter: amp', function() {
-	it('Should safely html-escape ampersands', function(done) {
+describe('Dust Filter: amp', function () {
+	it('Should safely html-escape ampersands', function (done) {
 		helper.render('{test1|s|amp} {test2|s|amp}', {
 			test1: '<p>A & B</p>',
 			test2: '<p>A &gt; & &#x8212; B &amp;</p>'
-		}, function(err, dom, str) {
+		}, function (err, dom, str) {
 			assert.strictEqual(str, '<p>A &amp; B</p> <p>A &gt; &amp; &#x8212; B &amp;</p>');
 			done();
 		});

--- a/tests/server/dust/and.js
+++ b/tests/server/dust/and.js
@@ -4,94 +4,94 @@
 var assert = require('proclaim');
 var helper = require('../../helpers/template.js')();
 
-describe('Dust Helper: and', function() {
-	it('Should treat an empty array as a falsy value (like dust) 3', function(done) {
+describe('Dust Helper: and', function () {
+	it('Should treat an empty array as a falsy value (like dust) 3', function (done) {
 		helper.render('{@and keys="foo|bar"}foobar{:else}baz{/and}', {
 			foo: [],
 			bar: 'hello'
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('baz', out);
 			done();
 		});
 	});
 
-	it('Should treat an empty array as a falsy value (like dust) 4', function(done) {
+	it('Should treat an empty array as a falsy value (like dust) 4', function (done) {
 		helper.render('{@and keys="foo|bar"}foobar{:else}baz{/and}', {
 			foo: [],
 			bar: []
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('baz', out);
 			done();
 		});
 	});
 
-	it('Should support a simple and test 1', function(done) {
+	it('Should support a simple and test 1', function (done) {
 		helper.render('{@and keys="foo|bar"}foobar{:else}baz{/and}', {
 			foo: 'hello'
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('baz', out);
 			done();
 		});
 	});
 
-	it('Should support a simple and test 2', function(done) {
+	it('Should support a simple and test 2', function (done) {
 		helper.render('{@and keys="foo|bar"}foobar{:else}baz{/and}', {
 			bar: 'hello'
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('baz', out);
 			done();
 		});
 	});
 
-	it('Should support a simple and test 3', function(done) {
+	it('Should support a simple and test 3', function (done) {
 		helper.render('{@and keys="foo|bar"}foobar{:else}baz{/and}', {
 			foo: 'hello',
 			bar: 'world'
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('foobar', out);
 			done();
 		});
 	});
 
-	it('Should support and with the not option 1', function(done) {
+	it('Should support and with the not option 1', function (done) {
 		helper.render('{@and keys="foo|bar" not="true"}foobar{:else}baz{/and}', {
 			foo: 'hello',
 			bar: 'world'
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('baz', out);
 			done();
 		});
 	});
 
-	it('Should support and with the not option 2', function(done) {
+	it('Should support and with the not option 2', function (done) {
 		helper.render('{@and keys="foo|bar" not="true"}foobar{:else}baz{/and}', {
 			foo: 'hello'
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('baz', out);
 			done();
 		});
 	});
 
-	it('Should support and with the not option 3', function(done) {
+	it('Should support and with the not option 3', function (done) {
 		helper.render('{@and keys="foo|bar" not="true"}foobar{:else}baz{/and}', {
 			baz: 'hello'
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('foobar', out);
 			done();
 		});
 	});
-	it('Should support "and" with nested properties: 1 level', function(done) {
+	it('Should support "and" with nested properties: 1 level', function (done) {
 		helper.render('{@and keys="foo|bar.bash"}foobar{:else}baz{/and}', {
 			foo: '1',
 			bar: {
 				bash: '2'
 			}
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('foobar', out);
 			done();
 		});
 	});
-	it('Should support "and" with nested properties: 2 levels', function(done) {
+	it('Should support "and" with nested properties: 2 levels', function (done) {
 		helper.render('{@and keys="foo|bar.bash.wibble"}foobar{:else}baz{/and}', {
 			foo: '1',
 			bar: {
@@ -99,29 +99,29 @@ describe('Dust Helper: and', function() {
 					wibble: '3'
 				}
 			}
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('foobar', out);
 			done();
 		});
 	});
-	it('Should support "and" to not return true for parents of nested properties', function(done) {
+	it('Should support "and" to not return true for parents of nested properties', function (done) {
 		helper.render('{@and keys="foo|bar.bash.wibble"}foobar{:else}baz{/and}', {
 			foo: '1',
 			bar: {
 				bash: '3'
 			}
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('baz', out);
 			done();
 		});
 	});
-	it('Should support "and" returning false if parent object is undefined', function(done) {
+	it('Should support "and" returning false if parent object is undefined', function (done) {
 		helper.render('{@and keys="foo|lorem.bash"}foobar{:else}baz{/and}', {
 			foo: '1',
 			bar: {
 				bash: '3'
 			}
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('baz', out);
 			done();
 		});

--- a/tests/server/dust/asset-path.js
+++ b/tests/server/dust/asset-path.js
@@ -4,16 +4,16 @@
 var assert = require('proclaim');
 var helper = require('../../helpers/template.js')();
 
-describe('Dust Helper: assetPath', function() {
-	it('Should render an asset path', function(done) {
-		helper.render('{@assetPath src="test.css"/}', {}, function(err, dom, out) {
+describe('Dust Helper: assetPath', function () {
+	it('Should render an asset path', function (done) {
+		helper.render('{@assetPath src="test.css"/}', {}, function (err, dom, out) {
 			assert.strictEqual('test.css', out);
 			done();
 		});
 	});
 
-	it('Should render an asset path from a variable', function(done) {
-		helper.render('{@assetPath src="{foo}.css"/}', {foo: 'test'}, function(err, dom, out) {
+	it('Should render an asset path from a variable', function (done) {
+		helper.render('{@assetPath src="{foo}.css"/}', {foo: 'test'}, function (err, dom, out) {
 			assert.strictEqual('test.css', out);
 			done();
 		});

--- a/tests/server/dust/date-format.js
+++ b/tests/server/dust/date-format.js
@@ -4,67 +4,67 @@
 var assert = require('proclaim');
 var helper = require('../../helpers/template.js')();
 
-describe('Dust Helper: dateFormat', function() {
-	it('Should render a date with the default format', function(done) {
-		helper.render('{@dateFormat date="2012-11-23" /}', {}, function(err, dom, out) {
+describe('Dust Helper: dateFormat', function () {
+	it('Should render a date with the default format', function (done) {
+		helper.render('{@dateFormat date="2012-11-23" /}', {}, function (err, dom, out) {
 			assert.strictEqual('2012-11-23', out);
 			done();
 		});
 	});
 
-	it('Should render a timestamp with the default format', function(done) {
-		helper.render('{@dateFormat date="1353668840128" /}', {}, function(err, dom, out) {
+	it('Should render a timestamp with the default format', function (done) {
+		helper.render('{@dateFormat date="1353668840128" /}', {}, function (err, dom, out) {
 			assert.strictEqual('2012-11-23', out);
 			done();
 		});
 	});
 
-	it('Should render a timestamp with a custom format 1', function(done) {
-		helper.render('{@dateFormat date="{date}" format="dd mmmm yyyy" /}', {date: (new Date('2012-11-23')).getTime()}, function(err, dom, out) {
+	it('Should render a timestamp with a custom format 1', function (done) {
+		helper.render('{@dateFormat date="{date}" format="dd mmmm yyyy" /}', {date: (new Date('2012-11-23')).getTime()}, function (err, dom, out) {
 			assert.strictEqual('23 November 2012', out);
 			done();
 		});
 	});
 
-	it('Should render a timestamp with a custom format 2', function(done) {
-		helper.render('{@dateFormat date="{date}" format="dd mmmm yyyy" /}', {date: (new Date('2012-11-01')).getTime()}, function(err, dom, out) {
+	it('Should render a timestamp with a custom format 2', function (done) {
+		helper.render('{@dateFormat date="{date}" format="dd mmmm yyyy" /}', {date: (new Date('2012-11-01')).getTime()}, function (err, dom, out) {
 			assert.strictEqual('01 November 2012', out);
 			done();
 		});
 	});
 
-	it('Should render a timestamp with a custom format 3', function(done) {
-		helper.render('{@dateFormat date="{date}" format="d mmmm yyyy" /}', {date: (new Date('2012-11-23')).getTime()}, function(err, dom, out) {
+	it('Should render a timestamp with a custom format 3', function (done) {
+		helper.render('{@dateFormat date="{date}" format="d mmmm yyyy" /}', {date: (new Date('2012-11-23')).getTime()}, function (err, dom, out) {
 			assert.strictEqual('23 November 2012', out);
 			done();
 		});
 	});
 
-	it('Should render a timestamp with a custom format 4', function(done) {
-		helper.render('{@dateFormat date="{date}" format="d mmmm yyyy" /}', {date: (new Date('2012-11-01')).getTime()}, function(err, dom, out) {
+	it('Should render a timestamp with a custom format 4', function (done) {
+		helper.render('{@dateFormat date="{date}" format="d mmmm yyyy" /}', {date: (new Date('2012-11-01')).getTime()}, function (err, dom, out) {
 			assert.strictEqual('1 November 2012', out);
 			done();
 		});
 	});
 
-	it('Should render the correct default value and format', function(done) {
-		helper.render('{@dateFormat /}', {}, function(err, dom, out1) {
-			helper.render('{@dateFormat date="{date}" format="yyyy-mm-dd" /}', {date: (new Date()).getTime()}, function(err, dom, out2) {
+	it('Should render the correct default value and format', function (done) {
+		helper.render('{@dateFormat /}', {}, function (err, dom, out1) {
+			helper.render('{@dateFormat date="{date}" format="yyyy-mm-dd" /}', {date: (new Date()).getTime()}, function (err, dom, out2) {
 				assert.strictEqual(out1, out2);
 				done();
 			});
 		});
 	});
 
-	it('Should return an empty string for an invalid date 1', function(done) {
-		helper.render('test{@dateFormat date="{date}" format="d mmmm yyyy" /}', {date: '2012-14-1000'}, function(err, dom, out) {
+	it('Should return an empty string for an invalid date 1', function (done) {
+		helper.render('test{@dateFormat date="{date}" format="d mmmm yyyy" /}', {date: '2012-14-1000'}, function (err, dom, out) {
 			assert.strictEqual('test', out);
 			done();
 		});
 	});
 
-	it('Should return an empty string for an invalid date 2', function(done) {
-		helper.render('test{@dateFormat date="{date}" format="d mmmm yyyy" /}', {date: 'hello'}, function(err, dom, out) {
+	it('Should return an empty string for an invalid date 2', function (done) {
+		helper.render('test{@dateFormat date="{date}" format="d mmmm yyyy" /}', {date: 'hello'}, function (err, dom, out) {
 			assert.strictEqual('test', out);
 			done();
 		});

--- a/tests/server/dust/html.js
+++ b/tests/server/dust/html.js
@@ -4,12 +4,12 @@
 var assert = require('proclaim');
 var helper = require('../../helpers/template.js')();
 
-describe('Dust Filter: html', function() {
-	it('Should safely escape HTML entities', function(done) {
+describe('Dust Filter: html', function () {
+	it('Should safely escape HTML entities', function (done) {
 		helper.render('{test1|s|html} {test2|s|html}', {
 			test1: '<script>alert("foo") && alert(\'bar\');</script>',
 			test2: '&#x8212; & &&amp; < >>> " &#60; &#62;'
-		}, function(err, dom, str) {
+		}, function (err, dom, str) {
 			assert.strictEqual(str, '&#60;script&#62;alert(&#34;foo&#34;) &amp;&amp; alert(&#39;bar&#39;);&#60;/script&#62; &#x8212; &amp; &amp;&amp; &#60; &#62;&#62;&#62; &#34; &#60; &#62;');
 			done();
 		});

--- a/tests/server/dust/lower.js
+++ b/tests/server/dust/lower.js
@@ -4,11 +4,11 @@
 var assert = require('proclaim');
 var helper = require('../../helpers/template.js')();
 
-describe('Dust Filter: lower', function() {
-	it('Should be able to convert a string to lower case', function(done) {
+describe('Dust Filter: lower', function () {
+	it('Should be able to convert a string to lower case', function (done) {
 		helper.render('{test|lower}', {
 			test: 'Hello World'
-		}, function(err, dom, str) {
+		}, function (err, dom, str) {
 			assert.strictEqual(str, 'hello world');
 			done();
 		});

--- a/tests/server/dust/number-format.js
+++ b/tests/server/dust/number-format.js
@@ -4,58 +4,58 @@
 var assert = require('proclaim');
 var helper = require('../../helpers/template.js')();
 
-describe('Dust Helper: numberFormat', function() {
-	it('Should display zero', function(done) {
-		helper.render('{@numberFormat num="{num}"/}', {num: 0}, function(err, dom, out) {
+describe('Dust Helper: numberFormat', function () {
+	it('Should display zero', function (done) {
+		helper.render('{@numberFormat num="{num}"/}', {num: 0}, function (err, dom, out) {
 			assert.strictEqual('0', out);
 			done();
 		});
 	});
 
-	it('Should display small numbers without punctuation 1', function(done) {
-		helper.render('{@numberFormat num="{num}"/}', {num: 1}, function(err, dom, out) {
+	it('Should display small numbers without punctuation 1', function (done) {
+		helper.render('{@numberFormat num="{num}"/}', {num: 1}, function (err, dom, out) {
 			assert.strictEqual('1', out);
 			done();
 		});
 	});
 
-	it('Should display small numbers without punctuation 2', function(done) {
-		helper.render('{@numberFormat num="{num}"/}', {num: 123}, function(err, dom, out) {
+	it('Should display small numbers without punctuation 2', function (done) {
+		helper.render('{@numberFormat num="{num}"/}', {num: 123}, function (err, dom, out) {
 			assert.strictEqual('123', out);
 			done();
 		});
 	});
 
-	it('Should format numbers with commas 1', function(done) {
-		helper.render('{@numberFormat num="{num}"/}', {num: 1234}, function(err, dom, out) {
+	it('Should format numbers with commas 1', function (done) {
+		helper.render('{@numberFormat num="{num}"/}', {num: 1234}, function (err, dom, out) {
 			assert.strictEqual('1,234', out);
 			done();
 		});
 	});
 
-	it('Should format numbers with commas 2', function(done) {
-		helper.render('{@numberFormat num="{num}"/}', {num: 12345}, function(err, dom, out) {
+	it('Should format numbers with commas 2', function (done) {
+		helper.render('{@numberFormat num="{num}"/}', {num: 12345}, function (err, dom, out) {
 			assert.strictEqual('12,345', out);
 			done();
 		});
 	});
 
-	it('Should format numbers with commas 3', function(done) {
-		helper.render('{@numberFormat num="{num}"/}', {num: 123456}, function(err, dom, out) {
+	it('Should format numbers with commas 3', function (done) {
+		helper.render('{@numberFormat num="{num}"/}', {num: 123456}, function (err, dom, out) {
 			assert.strictEqual('123,456', out);
 			done();
 		});
 	});
 
-	it('Should format numbers with commas 4', function(done) {
-		helper.render('{@numberFormat num="{num}"/}', {num: 1234567}, function(err, dom, out) {
+	it('Should format numbers with commas 4', function (done) {
+		helper.render('{@numberFormat num="{num}"/}', {num: 1234567}, function (err, dom, out) {
 			assert.strictEqual('1,234,567', out);
 			done();
 		});
 	});
 
-	it('Should not error on a non numeric value', function(done) {
-		helper.render('{@numberFormat num="{num}"/}', {num: 'pass'}, function(err, dom, out) {
+	it('Should not error on a non numeric value', function (done) {
+		helper.render('{@numberFormat num="{num}"/}', {num: 'pass'}, function (err, dom, out) {
 			assert.strictEqual('pass', out);
 			done();
 		});

--- a/tests/server/dust/or.js
+++ b/tests/server/dust/or.js
@@ -4,114 +4,114 @@
 var assert = require('proclaim');
 var helper = require('../../helpers/template.js')();
 
-describe('Dust Helper: or', function() {
-	it('Should support a simple or test 1', function(done) {
+describe('Dust Helper: or', function () {
+	it('Should support a simple or test 1', function (done) {
 		helper.render('{@or keys="foo|bar"}foobar{:else}baz{/or}', {
 			foo: 'hello'
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('foobar', out);
 			done();
 		});
 	});
 
-	it('Should support a simple or test 2', function(done) {
+	it('Should support a simple or test 2', function (done) {
 		helper.render('{@or keys="foo|bar"}foobar{:else}baz{/or}', {
 			bar: 'hello'
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('foobar', out);
 			done();
 		});
 	});
 
-	it('Should support else in a simple or test', function(done) {
+	it('Should support else in a simple or test', function (done) {
 		helper.render('{@or keys="foo|bar"}foobar{:else}baz{/or}', {
 			baz: 'hello'
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('baz', out);
 			done();
 		});
 	});
 
-	it('Should support or with the not option 1', function(done) {
+	it('Should support or with the not option 1', function (done) {
 		helper.render('{@or keys="foo|bar" not="true"}foobar{:else}baz{/or}', {
 			foo: 'hello',
 			bar: 'world'
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('baz', out);
 			done();
 		});
 	});
 
-	it('Should support or with the not option 2', function(done) {
+	it('Should support or with the not option 2', function (done) {
 		helper.render('{@or keys="foo|bar" not="true"}foobar{:else}baz{/or}', {
 			foo: 'hello'
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('foobar', out);
 			done();
 		});
 	});
 
-	it('Should treat an empty array as a falsy value (like dust) 1', function(done) {
+	it('Should treat an empty array as a falsy value (like dust) 1', function (done) {
 		helper.render('{@or keys="foo|bar"}foobar{:else}baz{/or}', {
 			foo: [],
 			bar: 'hello'
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('foobar', out);
 			done();
 		});
 	});
 
-	it('Should treat an empty array as a falsy value (like dust) 2', function(done) {
+	it('Should treat an empty array as a falsy value (like dust) 2', function (done) {
 		helper.render('{@or keys="foo|bar"}foobar{:else}baz{/or}', {
 			foo: [],
 			bar: []
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('baz', out);
 			done();
 		});
 	});
 
-	it('Should support "or" with nested properties: 1 level', function(done) {
+	it('Should support "or" with nested properties: 1 level', function (done) {
 		helper.render('{@or keys="foo|bar.bash"}foobar{:else}baz{/or}', {
 			bar: {
 				bash: 1
 			}
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('foobar', out);
 			done();
 		});
 	});
 
-	it('Should support "or" with nested properties: 2 levels', function(done) {
+	it('Should support "or" with nested properties: 2 levels', function (done) {
 		helper.render('{@or keys="foo|bar.bash.wibble"}foobar{:else}baz{/or}', {
 			bar: {
 				bash: {
 					wibble: 1
 				}
 			}
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('foobar', out);
 			done();
 		});
 	});
 
-	it('Should support "or" to not return true when only a parent property exists', function(done) {
+	it('Should support "or" to not return true when only a parent property exists', function (done) {
 		helper.render('{@or keys="foo|bar.bash.wibble"}foobar{:else}baz{/or}', {
 			bar: {
 				bash: 2
 			}
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('baz', out);
 			done();
 		});
 	});
 
-	it('Should support "or" to not return true when there is no parent object', function(done) {
+	it('Should support "or" to not return true when there is no parent object', function (done) {
 		helper.render('{@or keys="foo|lorem.bash"}foobar{:else}baz{/or}', {
 			bar: {
 				bash: 2
 			}
-		}, function(err, dom, out) {
+		}, function (err, dom, out) {
 			assert.strictEqual('baz', out);
 			done();
 		});

--- a/tests/server/dust/strip-tags.js
+++ b/tests/server/dust/strip-tags.js
@@ -4,11 +4,11 @@
 var assert = require('proclaim');
 var helper = require('../../helpers/template.js')();
 
-describe('Dust Filter: stripTags', function() {
-	it('Should be able to strip html from a string', function(done) {
+describe('Dust Filter: stripTags', function () {
+	it('Should be able to strip html from a string', function (done) {
 		helper.render('{test|stripTags}', {
 			test: '<p>Hello <a href="#">world</a></p>'
-		}, function(err, dom, str) {
+		}, function (err, dom, str) {
 			assert.strictEqual(str, 'Hello world');
 			done();
 		});

--- a/tests/server/dust/title.js
+++ b/tests/server/dust/title.js
@@ -4,11 +4,11 @@
 var assert = require('proclaim');
 var helper = require('../../helpers/template.js')();
 
-describe('Dust Filter: title', function() {
-	it('Should be able to convert a string to title case', function(done) {
+describe('Dust Filter: title', function () {
+	it('Should be able to convert a string to title case', function (done) {
 		helper.render('{test|title}', {
 			test: 'hello this is SOME @test text'
-		}, function(err, dom, str) {
+		}, function (err, dom, str) {
 			assert.strictEqual(str, 'Hello This Is Some @Test Text');
 			done();
 		});

--- a/tests/server/dust/trim.js
+++ b/tests/server/dust/trim.js
@@ -4,20 +4,20 @@
 var assert = require('proclaim');
 var helper = require('../../helpers/template.js')();
 
-describe('Dust Filter: trim', function() {
-	it('Should trim leading and trailing whitespace from a string', function(done) {
+describe('Dust Filter: trim', function () {
+	it('Should trim leading and trailing whitespace from a string', function (done) {
 		helper.render('{test|trim}', {
 			test: ' \t\r\nhello world   \n\t\r'
-		}, function(err, dom, str) {
+		}, function (err, dom, str) {
 			assert.strictEqual(str, 'hello world');
 			done();
 		});
 	});
 
-	it('Should not throw if the input is not a string', function(done) {
+	it('Should not throw if the input is not a string', function (done) {
 		helper.render('hello world{test|trim}', {
 			test: 3
-		}, function(err, dom, str) {
+		}, function (err, dom, str) {
 			assert.isNull(err);
 			assert.strictEqual(str, 'hello world3');
 			done();

--- a/tests/server/dust/upper.js
+++ b/tests/server/dust/upper.js
@@ -4,11 +4,11 @@
 var assert = require('proclaim');
 var helper = require('../../helpers/template.js')();
 
-describe('Dust Filter: upper', function() {
-	it('Should be able to convert a string to upper case', function(done) {
+describe('Dust Filter: upper', function () {
+	it('Should be able to convert a string to upper case', function (done) {
 		helper.render('{test|upper}', {
 			test: 'Hello World'
-		}, function(err, dom, str) {
+		}, function (err, dom, str) {
 			assert.strictEqual(str, 'HELLO WORLD');
 			done();
 		});

--- a/tests/server/filters/environment.js
+++ b/tests/server/filters/environment.js
@@ -5,22 +5,21 @@ var sinon = require('sinon');
 
 var filter = require('../../../filters/input/environment.js');
 
-describe('Populate data with environment info', function() {
-	// jscs:disable requireCamelCaseOrUpperCaseIdentifiers
+describe('Populate data with environment info', function () {
 	var callback;
 
-	beforeEach(function() {
+	beforeEach(function () {
 		callback = sinon.stub();
 	});
 
-	it('Should add the request url', function() {
+	it('Should add the request url', function () {
 		filter({}, {
 			url: '/hello'
 		}, {}, {}, callback);
 		assert.strictEqual(callback.firstCall.args[0].request_url, '/hello');
 	});
 
-	it('Should handle query parameters', function() {
+	it('Should handle query parameters', function () {
 		var params = {
 			test: 'Something'
 		};
@@ -33,11 +32,13 @@ describe('Populate data with environment info', function() {
 		assert.strictEqual(callback.firstCall.args[0].query_data.test, 'Something');
 	});
 
-	it('Should convert a query parameter containing true or false to a truthy value', function() {
+	it('Should convert a query parameter containing true or false to a truthy value', function () {
+		/* eslint-disable camelcase */
 		var params = {
 			show_ads: 'false',
 			disable_third_party_scripts: 'true'
 		};
+		/* eslint-enable camelcase */
 
 		filter({}, {
 			url: '/hello/world?show_ads=false&disable_third_party_scripts=true',
@@ -48,7 +49,7 @@ describe('Populate data with environment info', function() {
 		assert.strictEqual(callback.firstCall.args[0].query_data.disable_third_party_scripts, true);
 	});
 
-	it('Should convert a query parameter containing an integer to a numeric value', function() {
+	it('Should convert a query parameter containing an integer to a numeric value', function () {
 		var params = {
 			page: '2'
 		};
@@ -61,7 +62,7 @@ describe('Populate data with environment info', function() {
 		assert.strictEqual(callback.firstCall.args[0].query_data.page, 2);
 	});
 
-	it('Should support passing through arrays from the query data', function() {
+	it('Should support passing through arrays from the query data', function () {
 		var params = {
 			journals: ['hortres', 'mtm', 'true', '7']
 		};

--- a/tests/server/mocks/mincer.js
+++ b/tests/server/mocks/mincer.js
@@ -9,13 +9,13 @@ module.exports = {
 		use: sinon.stub()
 	},
 
-	Environment: function() {
+	Environment: function () {
 		this.findAsset = sinon.stub();
 		this.registerHelper = sinon.stub();
 		this.appendPath = sinon.stub();
 		this.prependPath = sinon.stub();
 	},
-	Manifest: function() {
+	Manifest: function () {
 		this.assets = {
 			'test.css': 'test-prod-md5.css'
 		};

--- a/tests/server/mocks/path.js
+++ b/tests/server/mocks/path.js
@@ -4,7 +4,7 @@ var sinon = require('sinon');
 
 module.exports = {
 	join: sinon.stub(),
-	basename: function(str) {
+	basename: function (str) {
 		var lastSlash = str.lastIndexOf('/');
 		var val = str.substring(lastSlash + 1);
 		val = val.replace('.dust', '');

--- a/tests/server/templates/namespace.js
+++ b/tests/server/templates/namespace.js
@@ -1,15 +1,15 @@
 
 'use strict';
 
-var assert = require('proclaim');
 var path = require('path');
+var assert = require('proclaim');
 var helper = require('../../helpers/template.js')();
 
 var rootDir = __dirname.substring(0, __dirname.indexOf('/tests/'));
 var templateDir = path.join(rootDir, 'view', 'tests');
 
-describe('Template overriding', function() {
-	before(function() {
+describe('Template overriding', function () {
+	before(function () {
 		helper.setup(
 			path.join(templateDir, 'namespace.dust'),
 			path.join(templateDir, 'a', 'b', 'loading.dust'),
@@ -20,13 +20,13 @@ describe('Template overriding', function() {
 	});
 	after(helper.teardown);
 
-	it('Should load templates relative to the namespace `tests`', function(done) {
+	it('Should load templates relative to the namespace `tests`', function (done) {
 		var json = {
 			layout: {
 				namespace: 'tests'
 			}
 		};
-		helper.render('namespace', json, function(err, $) {
+		helper.render('namespace', json, function (err, $) {
 			assert.isNull(err);
 
 			var expected = [
@@ -48,20 +48,20 @@ describe('Template overriding', function() {
 				}
 			];
 
-			$('[data-test="templates"]').children('dd').each(function(i, item) {
+			$('[data-test="templates"]').children('dd').each(function (i, item) {
 				assert.strictEqual(expected[i].path, $(item).text(), 'Loading template ' + expected[i].template);
 			});
 			done();
 		});
 	});
 
-	it('Should load templates relative to the namespace `tests__a`', function(done) {
+	it('Should load templates relative to the namespace `tests__a`', function (done) {
 		var json = {
 			layout: {
 				namespace: 'tests__a'
 			}
 		};
-		helper.render('namespace', json, function(err, $) {
+		helper.render('namespace', json, function (err, $) {
 			assert.isNull(err);
 
 			var expected = [
@@ -83,20 +83,20 @@ describe('Template overriding', function() {
 				}
 			];
 
-			$('[data-test="templates"]').children('dd').each(function(i, item) {
+			$('[data-test="templates"]').children('dd').each(function (i, item) {
 				assert.strictEqual(expected[i].path, $(item).text(), 'Loading template ' + expected[i].template);
 			});
 			done();
 		});
 	});
 
-	it('Should load templates relative to the namespace `tests__b`', function(done) {
+	it('Should load templates relative to the namespace `tests__b`', function (done) {
 		var json = {
 			layout: {
 				namespace: 'tests__b'
 			}
 		};
-		helper.render('namespace', json, function(err, $) {
+		helper.render('namespace', json, function (err, $) {
 			assert.isNull(err);
 
 			var expected = [
@@ -118,20 +118,20 @@ describe('Template overriding', function() {
 				}
 			];
 
-			$('[data-test="templates"]').children('dd').each(function(i, item) {
+			$('[data-test="templates"]').children('dd').each(function (i, item) {
 				assert.strictEqual(expected[i].path, $(item).text(), 'Loading template ' + expected[i].template);
 			});
 			done();
 		});
 	});
 
-	it('Should load templates relative to the namespace `tests__a__b`', function(done) {
+	it('Should load templates relative to the namespace `tests__a__b`', function (done) {
 		var json = {
 			layout: {
 				namespace: 'tests__a__b'
 			}
 		};
-		helper.render('namespace', json, function(err, $) {
+		helper.render('namespace', json, function (err, $) {
 			assert.isNull(err);
 
 			var expected = [
@@ -153,7 +153,7 @@ describe('Template overriding', function() {
 				}
 			];
 
-			$('[data-test="templates"]').children('dd').each(function(i, item) {
+			$('[data-test="templates"]').children('dd').each(function (i, item) {
 				assert.strictEqual(expected[i].path, $(item).text(), 'Loading template ' + expected[i].template);
 			});
 			done();


### PR DESCRIPTION
There were 24000 errors using the default rules, so this is too much to do all at once.

Set up:
* Remove jshint/jscs, add xo to package.json
* Move the jshintignore contents to the xo section in the package.json. Most of them weren't needed any more as xo uses .gitignore plus a number of common locations as default.
* Remove the other rc files from the repo.

Linting:
* Enable the appropriate environments in the xo section of the package.json - one for the whole project, and another one for the tests folder.
* Autofix all possible issues (which messed up lib/processor.js)
* Replace all the `jshint disable` rules with the appropriate `eslint` ones.
* Fix all the unfixed issues that didn't require a significant amount of investigation.
* There's a bunch of issues that will need further discussion, investigation or fixing. My approach to this has been to change the relevant rule to output a `warn` instead of disabling the rule completely, so we'll still get notified of the problems but the build will pass. These can be fixed later on.