### PR TITLE
Fix some linting warnings (which are now errors)

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -76,15 +76,16 @@ function serveRemoteJson(request, response, next) {
 		url: request.query.url,
 		headers: request.query.headers
 	};
+	var error;
 
 	if (!options.url || typeof options.url !== 'string') {
-		var error = new Error('Invalid query parameter: url');
+		error = new Error('Invalid query parameter: url');
 		error.status = 400;
 		return next(error);
 	}
 
 	if (options.headers && typeof options.headers !== 'string') {
-		var error = new Error('Invalid query parameter: headers');
+		error = new Error('Invalid query parameter: headers');
 		error.status = 400;
 		return next(error);
 	}
@@ -108,6 +109,8 @@ function loadRemoteJson(options, done) {
 		url: options.url,
 		headers: options.headers
 	};
+	var error;
+
 	request(requestOptions, function (err, response, body) {
 		if (err) {
 			return done(error);

--- a/bin/test-client.js
+++ b/bin/test-client.js
@@ -229,7 +229,7 @@ This script starts up a server, so you don't have to already have one running.
 			});
 			var exitCode = 0;
 			var message = 'Finished';
-			if (failures.length) {
+			if (failures.length > 0) {
 				exitCode = failures[0]; // Return first failure or 0
 				message += ' ' + failures.length + ' failures';
 			}
@@ -380,11 +380,13 @@ This script starts up a server, so you don't have to already have one running.
 		var sessionName;
 		var driver;
 
-		count = errors = 0;
+		count = 0;
+		errors = 0;
 		length = urls.length;
 		browserName = browser.browserName;
 		browserVersion = browser.version;
-		browser.name = sessionName = browserName + ' ' + browserVersion;
+		sessionName = browserName + ' ' + browserVersion;
+		browser.name = sessionName;
 
 		driver = wd.promiseRemote('ondemand.saucelabs.com', 80, saucelabsUser, saucelabsKey);
 		driver.init(browser)

--- a/lib/dispatch.js
+++ b/lib/dispatch.js
@@ -21,12 +21,6 @@ module.exports = function (config) {
 				statsd.increment('errors_' + status);
 			};
 
-			var getErrorContent = function (err, req, res) {
-				require('./error-pages')(config).getPage(err, req, res, function (content) {
-					doSend(content || api.error(err, status));
-				});
-			};
-
 			var doSend = function (content) {
 				var length = Buffer.byteLength(content);
 				if (!mimeType) {
@@ -40,6 +34,12 @@ module.exports = function (config) {
 				res.setHeader('Content-length', length);
 				res.writeHead(status);
 				res.end(content);
+			};
+
+			var getErrorContent = function (err, req, res) {
+				require('./error-pages')(config).getPage(err, req, res, function (content) {
+					doSend(content || api.error(err, status));
+				});
 			};
 
 			if (!status) {

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -8,7 +8,7 @@ module.exports = function (dust, renderer, config) {
 	// and to not blow up if the template is not found
 	dust.onLoad = function (name, options, callback) {
 		var getTemplate = function (namespace) {
-			if (!namespace.length) {
+			if (namespace.length === 0) {
 				return dust.cache[name];
 			}
 			namespace.push(name);

--- a/lib/input-filter.js
+++ b/lib/input-filter.js
@@ -28,7 +28,7 @@ module.exports = function (config) {
 				var arity;
 				var cb;
 
-				if (filters.length) {
+				if (filters.length > 0) {
 					filter = filters[0];
 					remain = filters.slice(1);
 					cb = function (data) {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -66,25 +66,6 @@ module.exports = function (config, renderer) {
 				return acceptedType && acceptedMethod;
 			};
 
-			var writeHead = function (code) {
-				statsd.increment('total_requests');
-
-				if (shouldIntercept()) {
-					res.write = write;
-					res.end = endIntercept;
-					status = code;
-					if (req.__proxyTimingFunctionHeadersReceived) {
-						statsd.classifiedTiming(req.url, 'proxy_headers_received', req.__proxyTimingFunctionHeadersReceived('Received headers ' + req.url));
-					}
-				} else if (proxyErr) {
-					res.write = write;
-					res.end = endProxyError;
-					status = code;
-				} else {
-					res.__originalWriteHead.apply(res, [].slice.call(arguments, 0));
-				}
-			};
-
 			var write = function (chunk) {
 				data.push(chunk);
 			};
@@ -121,11 +102,30 @@ module.exports = function (config, renderer) {
 						return dispatch.send(null, jsonOutput, req, res, status);
 					}
 
-					var timer = config.timer();
+					timer = config.timer();
 					renderer.render(req, res, json.data, function (err, out) {
 						statsd.classifiedTiming(req.url, 'rendering', timer('Rendering ' + req.url));
 						dispatch.send(err, out, req, res, status);
 					});
+				}
+			};
+
+			var writeHead = function (code) {
+				statsd.increment('total_requests');
+
+				if (shouldIntercept()) {
+					res.write = write;
+					res.end = endIntercept;
+					status = code;
+					if (req.__proxyTimingFunctionHeadersReceived) {
+						statsd.classifiedTiming(req.url, 'proxy_headers_received', req.__proxyTimingFunctionHeadersReceived('Received headers ' + req.url));
+					}
+				} else if (proxyErr) {
+					res.write = write;
+					res.end = endProxyError;
+					status = code;
+				} else {
+					res.__originalWriteHead.apply(res, [].slice.call(arguments, 0));
 				}
 			};
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -31,7 +31,7 @@ module.exports = function (config) {
 
 	var restart = function () {
 		var replace = function (workers) {
-			if (!workers.length) {
+			if (workers.length === 0) {
 				config.log.info('All replacement workers now running');
 				return;
 			}

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -24,7 +24,7 @@ module.exports = function (config) {
 
 	var obj = {
 		buildMetricNameForUrl: function (url, name) {
-			if (!mappings.length) {
+			if (mappings.length === 0) {
 				return name;
 			}
 			for (var i = 0; mappings[i]; ++i) {

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -3,6 +3,11 @@
 
 // Watch a file tree for changes using Gaze
 module.exports = function (extension) {
+	var constructGlob = function (dirpath) {
+		var glob = '/**/*' + extension;
+		return dirpath + glob;
+	};
+
 	var watchTree = function (directories, log) {
 		var Gaze = require('gaze');
 		var watchedDirs = (typeof directories === 'string') ? constructGlob(directories) : directories.map(constructGlob);
@@ -15,11 +20,6 @@ module.exports = function (extension) {
 		});
 		watcher.on('error', log.error);
 		return watcher;
-	};
-
-	var constructGlob = function (dirpath) {
-		var glob = '/**/*' + extension;
-		return dirpath + glob;
 	};
 
 	return {

--- a/package.json
+++ b/package.json
@@ -104,14 +104,11 @@
     "rules": {
       "block-scoped-var": "warn",
       "no-lonely-if": "warn",
-      "no-multi-assign": "warn",
       "no-path-concat": "warn",
       "no-prototype-builtins": "warn",
       "no-redeclare": "warn",
       "no-undef": "warn",
-      "no-use-before-define": "warn",
       "no-useless-escape": "warn",
-      "unicorn/explicit-length-check": "warn",
       "unicorn/no-new-buffer": "warn"
     },
     "overrides": [

--- a/tests/helpers/template.js
+++ b/tests/helpers/template.js
@@ -24,7 +24,7 @@ module.exports = function (env) {
 			renderer = require('../../lib/renderer')(config);
 			assetPath = sinon.stub(renderer, 'assetPath').returnsArg(0);
 			renderer.initDustExtensions();
-			if (args.length) {
+			if (args.length > 0) {
 				if (args[0] === 'all') {
 					// We need to pretend to the renderer it is being called from a host app, not the Mocka process
 					renderer.compileTemplates('.');

--- a/tests/server/core/processor.js
+++ b/tests/server/core/processor.js
@@ -375,7 +375,7 @@ describe('Request processor', function () {
 		beforeEach(function () {
 			renderer = require('../mocks/renderer')();
 			dispatch = require('./dispatch')();
-			processor = processor = require(moduleName)(mockConfig, renderer);
+			processor = require(moduleName)(mockConfig, renderer);
 		});
 
 		afterEach(function () {


### PR DESCRIPTION
The following rules:
* `"no-multi-assign": "warn"`
* `"no-use-before-define": "warn"`
* `"unicorn/explicit-length-check": "warn"`

Where added as part of #182 in order to deal with the huge number of errors caused by the new linting rules.

This removes those three rules from the `package.json` therefore making those rules error again, and fixes all the related errors (plus a few other small ones).