### PR TITLE
Remove legacy configuration options, fix configuration bugs

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -86,10 +86,7 @@
 	"excludeFiles": [
 		"node_modules/**",
 		"public/**",
-		"resources/js/plugins/**",
-		"resources/js/jquery-1.9.1.js",
 		"tests/client/lib/**",
-		"themes/**",
 		"./coverage"
 	]
 }

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,7 +1,4 @@
 node_modules
 public
-resources/js/plugins
-resources/js/jquery-*
 tests/client/lib
-themes
 ./coverage

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,11 +87,6 @@ var shunter = require('shunter');
 // Create a Shunter application, passing in options
 var app = shunter({
 
-    // Configure the themes path to the current directory
-    path: {
-        themes: __dirname
-    },
-
     // Configure the proxy route, this should point to
     // where your back end application runs
     routes: {

--- a/docs/usage/configuration-reference.md
+++ b/docs/usage/configuration-reference.md
@@ -36,7 +36,7 @@ web: {
 Path Configuration
 ------------------
 
-The path object defines the paths to some of the key directories used by Shunter. This includes the application root path, paths to tests, themes and public resources:
+The path object defines the paths to some of the key directories used by Shunter. This includes the application root path, paths to tests, resources, etc.:
 
 ```js
 path: {
@@ -48,8 +48,7 @@ path: {
     root: appRoot,
     shunterRoot: shunterRoot,
     templates: path.join(appRoot, 'view'),
-    tests: path.join(appRoot, 'tests'),
-    themes: path.join(shunterRoot, 'themes')
+    tests: path.join(appRoot, 'tests')
 }
 ```
 
@@ -253,10 +252,7 @@ The items above are the default configurations which may be over-ridden. You wil
 var app = shunter({
     routes: require('./config/routes.json'),
     statsd: require('./config/statsd.json'),
-    syslogAppName: 'my-shunter-app',
-    path: {
-        themes: __dirname
-    }
+    syslogAppName: 'my-shunter-app'
 });
 ```
 

--- a/docs/usage/configuration-reference.md
+++ b/docs/usage/configuration-reference.md
@@ -46,7 +46,6 @@ path: {
     publicResources: path.join(appRoot, 'public', 'resources'),
     resources: path.join(appRoot, 'resources'),
     root: appRoot,
-    shunterResources: path.join(shunterRoot, 'resources'),
     shunterRoot: shunterRoot,
     templates: path.join(appRoot, 'view'),
     tests: path.join(appRoot, 'tests'),

--- a/docs/usage/configuration-reference.md
+++ b/docs/usage/configuration-reference.md
@@ -47,7 +47,6 @@ path: {
     resources: path.join(appRoot, 'resources'),
     root: appRoot,
     shunterRoot: shunterRoot,
-    templates: path.join(appRoot, 'view'),
     tests: path.join(appRoot, 'tests')
 }
 ```

--- a/docs/usage/resources.md
+++ b/docs/usage/resources.md
@@ -100,7 +100,7 @@ Static assets are possible, but you should only use these when you are unable to
 
 By default, assets in the `public` subdirectory are served on the path `public`.
 
-If it isn't convenient to have one or both of these as 'public' you can override them by setting the config option in your `local.json` file using `config.path.public` for where the assets are saved and `config.web.public` for the path that you would like to serve them on.
+If it isn't convenient to have one or both of these as 'public' you can override them by setting the config option using `config.path.public` for where the assets are saved and `config.web.public` for the path that you would like to serve them on.
 
 
 Built In EJS Extensions

--- a/lib/config.js
+++ b/lib/config.js
@@ -135,8 +135,7 @@ module.exports = function (env, config, args) {
 			root: appRoot,
 			shunterRoot: shunterRoot,
 			templates: path.join(appRoot, 'view'),
-			tests: path.join(appRoot, 'tests'),
-			themes: path.join(shunterRoot, 'themes')
+			tests: path.join(appRoot, 'tests')
 		},
 		statsd: {
 			host: 'localhost',

--- a/lib/config.js
+++ b/lib/config.js
@@ -133,7 +133,6 @@ module.exports = function (env, config, args) {
 			publicResources: path.join(appRoot, 'public', 'resources'),
 			resources: path.join(appRoot, 'resources'),
 			root: appRoot,
-			shunterResources: path.join(shunterRoot, 'resources'),
 			shunterRoot: shunterRoot,
 			templates: path.join(appRoot, 'view'),
 			tests: path.join(appRoot, 'tests'),

--- a/lib/config.js
+++ b/lib/config.js
@@ -134,7 +134,6 @@ module.exports = function (env, config, args) {
 			resources: path.join(appRoot, 'resources'),
 			root: appRoot,
 			shunterRoot: shunterRoot,
-			templates: path.join(appRoot, 'view'),
 			tests: path.join(appRoot, 'tests')
 		},
 		statsd: {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -149,23 +149,11 @@ module.exports = function (config) {
 				paths = [].slice.call(arguments, 0);
 			}
 			paths.forEach(function (name) {
-				// DEPRECATED: checking both themes and templates folders for the right template file
-				// when updated, should just look for 'self.compileFile(name));'
-				// name will need to be full path, or contain the relevant subfolders e.g. laserwolf/views/subject/foo.dust
-
-				if (fs.existsSync(path.join(config.path.themes, name))) {
-					// Themes
-					self.compileFile(path.join(config.path.themes, name));
-				} else if (fs.existsSync(path.join(config.path.templates, name))) {
-					// Old shunter-proxy
-					self.compileFile(path.join(config.path.templates, name));
-				} else if (fs.existsSync(name)) {
-					// Full path
+				if (fs.existsSync(name)) {
 					self.compileFile(name);
 				} else {
 					config.log.info('Could not find template ' + name);
 				}
-				// End DEPRECATED
 			});
 		},
 
@@ -180,7 +168,7 @@ module.exports = function (config) {
 			});
 			// Then get the app's templates
 			// (must use / for glob even with windows)
-			var templates = [config.path.themes, config.structure.templates, '**', ('*' + config.structure.templateExt)].join('/');
+			var templates = [hostAppDir, config.structure.templates, '**', ('*' + config.structure.templateExt)].join('/');
 			fullFiles = fullFiles.concat(glob.sync(templates, {}));
 			this.compileFileList(fullFiles);
 		},
@@ -191,7 +179,7 @@ module.exports = function (config) {
 			config.modules.map(function (module) {
 				return path.join(hostAppDir, 'node_modules', module, localPath);
 			}).concat([
-				path.join(config.path.themes, localPath)
+				path.join(hostAppDir, localPath)
 			]).filter(function (file) {
 				return fs.existsSync(file);
 			}).forEach(function (file) {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -119,7 +119,7 @@ module.exports = function (config) {
 			if (path.extname(fp) === ext) {
 				sandboxNS = path.relative(config.path.themes, fp);
 				// Trim out the relative paths of inherited templates
-				sandboxNS = sandboxNS.substring(sandboxNS.indexOf('view'));
+				sandboxNS = sandboxNS.substring(sandboxNS.indexOf(config.structure.templates));
 				splitPath = sandboxNS.split(path.sep);
 				if (splitPath.indexOf(config.structure.templates) > -1) {
 					// Remove internal structure path
@@ -198,7 +198,7 @@ module.exports = function (config) {
 		watchTemplates: function () {
 			var watchTree;
 			var watcher;
-			var folders = [config.path.templates];
+			var folders = [config.structure.templates];
 			var self = this;
 
 			var compile = function (fp) {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -117,7 +117,7 @@ module.exports = function (config) {
 			var timer;
 
 			if (path.extname(fp) === ext) {
-				sandboxNS = path.relative(config.path.themes, fp);
+				sandboxNS = fp;
 				// Trim out the relative paths of inherited templates
 				sandboxNS = sandboxNS.substring(sandboxNS.indexOf(config.structure.templates));
 				splitPath = sandboxNS.split(path.sep);

--- a/tests/helpers/template.js
+++ b/tests/helpers/template.js
@@ -2,12 +2,12 @@
 
 process.env.TZ = 'UTC';
 
-module.exports = function (env) {
+module.exports = function (config) {
 	var fs = require('fs');
 	var path = require('path');
 	var cheerio = require('cheerio');
 	var sinon = require('sinon');
-	var config = require('../../lib/config')(env || 'development', null, {});
+	var config = require('../../lib/config')('development', config || null, {});
 
 	var renderer = null;
 	var assetPath = null;

--- a/tests/server/core/dispatch.js
+++ b/tests/server/core/dispatch.js
@@ -50,7 +50,6 @@ describe('Dispatching response', function () {
 				root: '/',
 				resources: '/resources',
 				publicResources: '/public/resources',
-				themes: '/themes',
 				templates: '/view',
 				dust: '/dust'
 			},

--- a/tests/server/core/error-pages.js
+++ b/tests/server/core/error-pages.js
@@ -65,7 +65,6 @@ describe('Templating error pages', function () {
 				root: '/',
 				resources: '/resources',
 				publicResources: '/public/resources',
-				themes: '/themes',
 				templates: '/view',
 				dust: '/dust'
 			},

--- a/tests/server/core/renderer.js
+++ b/tests/server/core/renderer.js
@@ -12,7 +12,6 @@ var mockConfig = {
 		root: '/',
 		resources: '/resources',
 		publicResources: '/public/resources',
-		themes: '/themes',
 		templates: '/view',
 		dust: '/dust'
 	},

--- a/tests/server/core/renderer.js
+++ b/tests/server/core/renderer.js
@@ -87,6 +87,7 @@ describe('Renderer', function () {
 		mockery.disable();
 		mockConfig.env.isProduction.returns(true);
 		mockConfig.log.error.reset();
+		mockConfig.structure.templates = 'view';
 	});
 
 	describe('Asset handling', function () {
@@ -281,14 +282,28 @@ describe('Renderer', function () {
 	});
 
 	describe('Template compilation', function () {
-		it('Should watch the templates directories', function () {
+		it('Should watch the default templates directories', function () {
 			require('fs').readdirSync.returns([]);
 			require('path').join.returns('/module/view');
 			var renderer = require(RENDERER_MODULE)(mockConfig);
 
 			renderer.watchTemplates();
 			assert.isTrue(watcher().watchTree.calledOnce);
-			assert.isTrue(watcher().watchTree.calledWith(['/view', '/module/view'], mockConfig.log));
+			assert.isTrue(watcher().watchTree.calledWith(['view', '/module/view'], mockConfig.log));
+			assert.isTrue(watcher().watchTree().on.calledWith('fileModified'));
+			assert.isTrue(watcher().watchTree().on.calledWith('fileCreated'));
+		});
+
+		it('Should watch the configured templates directories', function () {
+			require('fs').readdirSync.returns([]);
+			require('path').join.returns('/module/templates');
+			var alternativeMockConfig = mockConfig;
+			alternativeMockConfig.structure.templates = 'templates';
+			var renderer = require(RENDERER_MODULE)(alternativeMockConfig);
+
+			renderer.watchTemplates();
+			assert.isTrue(watcher().watchTree.calledOnce);
+			assert.isTrue(watcher().watchTree.calledWith(['templates', '/module/templates'], mockConfig.log));
 			assert.isTrue(watcher().watchTree().on.calledWith('fileModified'));
 			assert.isTrue(watcher().watchTree().on.calledWith('fileCreated'));
 		});
@@ -440,7 +455,7 @@ describe('Renderer', function () {
 			assert.strictEqual(renderer.dust.loadSource.callCount, 0);
 		});
 
-		it('Should select all dust files from a configured theme directory\'s subfolders', function () {
+		it('Should select all dust files from application\'s configured template directory\'s subfolders', function () {
 			require('fs').readdirSync.returns([]);
 			var renderer = require(RENDERER_MODULE)(mockConfig);
 			var gsync = require('glob').sync.returns(['filepath']);

--- a/tests/server/mocks/renderer.js
+++ b/tests/server/mocks/renderer.js
@@ -9,6 +9,5 @@ module.exports = sinon.stub().returns({
 	watchDustExtensions: sinon.stub(),
 	assetServer: sinon.stub(),
 	render: sinon.stub(),
-	renderPartial: sinon.stub(),
-	themes: []
+	renderPartial: sinon.stub()
 });


### PR DESCRIPTION
* Removes the following legacy configuration options which are no longer required:
  - `config.path.themes` - vestigial feature from when a single shunter instance would run multiple apps ("themes").  Now always set to the root directory of the host app, so no longer needed
  - `config.path.shunterResources` - Shunter no longer contains any default resources
  - `config.path.templates` - unused

* Allows custom configuration options to be passed to the Shunter testhelper for testing templates.
* Fix bug whereby Shunter would break if a user set a value for `config.structure.templates` other than the default `view`.

**This pull request is a work in progress** - opening now so I can document changes as I go.

TODO: 
- consider changing behaviour and documentation around module use and `local.json` (no reason for this to be done any differently to setting other custom config - might be worth clarifying using the local json file is just an alternative method for setting all config).
- test-client.js provides no way to change default config, so will fail if `config.structure.resources` is changed from default (or any other paths referenced in that script)