### PR TITLE
Input filters async support

### DIFF
--- a/filters/input/environment.js
+++ b/filters/input/environment.js
@@ -2,7 +2,7 @@
 
 var qs = require('qs');
 
-module.exports = function (config, req, res, data, next) {
+module.exports = function (data, req, res, config ) {
 	var cast = function (params) {
 		var output = {};
 
@@ -35,5 +35,5 @@ module.exports = function (config, req, res, data, next) {
 	data.request_url = (req.url) ? req.url.replace(/\?.*$/, '') : '';
 	/* eslint-enable camelcase */
 
-	next(data);
+	return data;
 };

--- a/lib/input-filter.js
+++ b/lib/input-filter.js
@@ -19,6 +19,11 @@ module.exports = function (config) {
 			this.filters.push(filter);
 		},
 
+		newrunner: function (req, res, data, callback) {
+			console.log('Filters: ' , this.filters.length);
+			callback(data);
+
+		},
 		run: function (req, res, data, callback) {
 			var self = this;
 

--- a/lib/input-filter.js
+++ b/lib/input-filter.js
@@ -19,11 +19,17 @@ module.exports = function (config) {
 			this.filters.push(filter);
 		},
 
-		newrunner: function (req, res, data, callback) {
-			console.log('Filters: ' , this.filters.length);
-			callback(data);
-
+		asyncRunner: async function (req, res, data) {
+			for (let filter of this.filters) {
+				try {
+					data = await Promise.resolve(filter(data, req, res, config));
+				} catch (error) {
+					config.log.error('Some filters cannot be applied, skipped.' , error);
+				}
+			}
+			return data;
 		},
+		
 		run: function (req, res, data, callback) {
 			var self = this;
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -255,7 +255,7 @@ module.exports = function (config) {
 		},
 
 		renderPartial: function (partial, req, res, data, callback) {
-			inputFilters.run(req, res, data, function (data) {
+			inputFilters.newrunner(req, res, data, function (data) {
 				var ns = (data && data.layout && data.layout.namespace) ? data.layout.namespace : null;
 				var base = dust.makeBase({
 					namespace: ns

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -255,7 +255,7 @@ module.exports = function (config) {
 		},
 
 		renderPartial: function (partial, req, res, data, callback) {
-			inputFilters.newrunner(req, res, data, function (data) {
+			inputFilters.asyncRunner(req, res, data).then(data => {
 				var ns = (data && data.layout && data.layout.namespace) ? data.layout.namespace : null;
 				var base = dust.makeBase({
 					namespace: ns
@@ -265,6 +265,8 @@ module.exports = function (config) {
 				dust.render(partial, base.push(data), function (err, out) {
 					callback(err, out);
 				});
+			}).catch(error => {
+				config.log.error('Error on render:' , error);
 			});
 		}
 	};


### PR DESCRIPTION
Currently, for each input filter we can pass cb, and if there is not a callback, it will consider the function synchronize:

```
module.exports = function (json) {
    return json;  
}
```

Or for a async operation:

```
module.exports = function (data, cb) {
     cb(data);
}
```

In this PR, we are adding async/await usage for filtering. Given that we won't need to call the function callback, and it will be possible to return a Promise object directly from the filter:

```
module.exports = function (data) {
   return Promise.resolve(data);
}
```
Or in ES7 style:
```
module.exports = async function (data, cb) {
    data = (await Task1(data)).items.map(x => x +1);
    return data;
}
```

Having said that, many parts of product might have simpler code, specially the way filters are applying one after other.
The biggest issue is neglecting backward compatibility, since input filters can have up to 5 arguments and there is way to detect accurately if they are accepting callback or not.
One way is to detect if function returns undefined, so then we assume it's callback, but since arguments count range is 1-5, it make it impossible.


