### PR TITLE
Change test commands and add snyk test to build

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.7.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'npm:tunnel-agent:20170305':
+    - wd > request > tunnel-agent:
+        reason: No fixes available
+        expires: '2017-09-02T12:42:54.426Z'
+patch: {}

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ branches:
 
 # Build script
 script:
-  - 'if [ $LINT ]; then make lint; fi'
-  - 'if [ ! $LINT ]; then make lcov-levels; fi'
+  - 'if [ $LINT ]; then npm run lint; fi'
+  - 'if [ ! $LINT ]; then npm run test; fi'
 
 # Updates the dashboard after a successful deployment
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,7 @@ xo:
 	@./node_modules/.bin/xo
 
 # Run all tests
-test: snyk-test test-server
-
-# Run snyk test
-snyk-test:
-	@echo "$(C_CYAN)> running 'snyk test'$(C_RESET)"
-	@./node_modules/.bin/snyk test
+test: lcov-levels
 
 # Run unit tests
 test-server:

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "shunter-test-client": "./bin/test-client.js"
   },
   "scripts": {
-    "test": "make test"
+    "lint": "make lint",
+    "test": "snyk test && make test"
   },
   "xo": {
     "esnext": false,


### PR DESCRIPTION
This changes the makefile, travis config and npm scripts in order to follow some common conventions.

This allows now for us to run snyk test as part of the build process in travis.

Also adds .snyk file with a policy to ignore the only present vulnerability for 30 days - this allows all tests to pass successfully.