### PR TITLE
Version 4.10.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,14 @@
 
 # History
 
+## 4.10.1 (2017-08-04)
+
+* Upgrade jserve to 2.0.3. Fixes a vulnerability in the ms library: https://snyk.io/test/npm/jserve/2.0.2
+* Change the travis config and npm scripts in order to make `npm test` consistent between environments.
+* Add Snyk policy file and full integration of Snyk with the build process.
+
 ## 4.10.0 (2017-07-17)
+
 * Support template rendering in client side tests
 
 ## 4.9.0 (2017-06-28)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shunter",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "license": "LGPL-3.0",
   "description": "A Node.js application built to read JSON and translate it into HTML",
   "keywords": [


### PR DESCRIPTION
* Upgrade jserve to 2.0.3. Fixes a vulnerability in the ms library: https://snyk.io/test/npm/jserve/2.0.2
* Change the travis config and npm scripts in order to make `npm test` consistent between environments.
* Add Snyk policy file and full integration of Snyk with the build process.