### PR TITLE
Disable package-lock.json file in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
We haven't reached a decision regarding the use of a package lock, so this will disable the creation of the file for now when using npm@5+.