### PR TITLE
Require one argument for optional parameters

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -11,18 +11,21 @@ var yargs = require('yargs');
 var args = yargs
 	.options('p', {
 		alias: 'port',
+		nargs: 1,
 		default: 5401,
 		type: 'number',
 		describe: 'Port number'
 	})
 	.options('d', {
 		alias: 'data',
+		nargs: 1,
 		default: './data',
 		type: 'string',
 		describe: 'The path to look for sample data in'
 	})
 	.options('l', {
 		alias: 'latency',
+		nargs: 1,
 		default: 0,
 		type: 'number',
 		describe: 'Add milliseconds of latency to the request'


### PR DESCRIPTION
When an optional parameter like `-p` that requires an argument is used but an argument is not passed, this will cause the app to fail as expected instead of using a random value. For example, port was being set to 3000 instead of the default 5401.

This hopefully addresses #145.