### PR TITLE
Update travis to allow failure on unsupported node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,19 +15,12 @@ matrix:
     # Run tests in Node.js 6.x
     - node_js: '6'
 
+    # Run tests in Node.js 8.x
+    - node_js: '8'
+
+  allow_failures:
     # Run tests in the latest version of Node.js
     - node_js: 'node'
-
-# Dependencies require GCC 4.8
-env:
-  global:
-    CXX=g++-4.8
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
 
 # Restrict builds on branches
 branches:


### PR DESCRIPTION
As Node 9 has just been released, this change adds tests for node versions 8 and 9 but allows tests for version 9 to fail, as it's technically not supported by this version of shunter.

It also removes the old GCC 4.8 config, which shouldn't be needed anymore now that Travis has migrated to Ubuntu Trusty.