### PR TITLE
Render on detection of configurable header (not just Content-type)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ Technically speaking Shunter runs your loosely-coupled front end as a node.js se
 
 ![Shunter as a proxy](diagram.png)
 
-When a request comes in from a client, it's proxied through to your back end application (or can use multiple back ends using some simple [routing logic](usage/routing.md)).  Any JSON response which is sent back with the special `Content-Type` `application/x-shunter+json` response header will be taken by Shunter and [transformed using Dust.js](usage/templates.md), while any other resource is transparently passed back through to the client.
+When a request comes in from a client, it's proxied through to your back end application (or can use multiple back ends using some simple [routing logic](usage/routing.md)).  Any JSON response which is sent back with the [special response header](usage/configuration-reference.md#trigger-parameter) (by default `Content-Type` `application/x-shunter+json`) will be taken by Shunter and [transformed using Dust.js](usage/templates.md), while any other resource is transparently passed back through to the client.
 
 
 Prerequisites

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -14,7 +14,7 @@ Technically speaking Shunter runs your loosely-coupled front end as a node.js se
 
 ![Shunter as a proxy](diagram.png)
 
-When a request comes in from a user, it's proxied through to your back end application (or can use multiple back ends using some simple [routing logic](usage/routing.md)).  Any JSON response which is sent back with the special `Content-Type` `application/x-shunter+json` will be taken by Shunter and [transformed using Dust.js](usage/templates.md), while any other resource is transparently passed back through to the user.
+When a request comes in from a user, it's proxied through to your back end application (or can use multiple back ends using some simple [routing logic](usage/routing.md)).  Any JSON response which is sent back with the [special  response header](usage/configuration-reference.md#trigger-parameter) (by default `Content-Type` `application/x-shunter+json`) will be taken by Shunter and [transformed using Dust.js](usage/templates.md), while any other resource is transparently passed back through to the user.
 
 ---
 

--- a/docs/usage/configuration-reference.md
+++ b/docs/usage/configuration-reference.md
@@ -10,6 +10,7 @@ The config object passed to an instance of Shunter can append or overwrite Shunt
 - [Log](#log-configuration)
 - [StatsD](#statsd-configuration)
 - [Timer](#timer-configuration)
+- [Trigger Parameter](#trigger-parameter)
 - [JSON View Parameter](#json-view-parameter)
 - [Environment](#environment-configuration)
 - [Templated Error Pages](#templated-error-page-configuration)
@@ -150,6 +151,23 @@ timer: function() {
 },
 ```
 
+Trigger Parameter
+-----------------
+
+The trigger object defines the name of the response header that will be inspected in order to decide whether to transform the response or pass it through to the client.
+
+This setting allows you to transform responses without munging the Content-type in the upstream service - useful if your service uses HATEOAS mime-type versioning for example.
+
+The default value is:
+
+```js
+trigger {
+    header: 'Content-type',
+    matchExpression: 'application/x-shunter\\+json' 
+}
+```
+
+Any proxied responses with a Content-type of `application/x-shunter+json` will be transformed. The matchExpression is a case-insensitive regular expression that is applied to the value of the named header.
 
 JSON View Parameter
 -------------------

--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -15,7 +15,7 @@ View templates in Shunter are written in [Dust](http://www.dustjs.com/) and live
 Specifying a Template
 ---------------------
 
-When JSON is received from the back end with `Content-Type: application/x-shunter+json`, Shunter will look for a `layout.template` property and attempt to render the matching Dust file. So with the following JSON:
+When a JSON response is received from the back end with the (configured trigger header)[configuration-reference.md#trigger-parameter] (default: `Content-Type: application/x-shunter+json`), Shunter will look for a `layout.template` property and attempt to render the matching Dust file. So with the following JSON:
 
 ```json
 {
@@ -39,7 +39,7 @@ Templates cannot contain "/" characters in Shunter, instead if you need to refer
 
 Shunter will attempt to render the file `view/foo/bar.dust`.
 
-If JSON is received without specifying `application/x-shunter+json` as the `Content-Type` then Shunter will simply pass it through unmodified as it would any other resource.
+If a JSON response is received without the (configured trigger header)[configuration-reference.md#trigger-parameter] then Shunter will simply pass it through unmodified as it would any other resource.
 
 
 Dust Basics

--- a/lib/config.js
+++ b/lib/config.js
@@ -163,6 +163,10 @@ module.exports = function (env, config, args) {
 			templates: 'view',
 			tests: 'tests'
 		},
+		trigger: {
+			header: 'Content-type',
+			matchExpression: 'application/x-shunter\\+json'
+		},
 		timer: function () {
 			var start = Date.now();
 			return function (msg) {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -57,13 +57,19 @@ module.exports = function (config, renderer) {
 			var data = [];
 			var status = null;
 
+			var trigger = config.trigger || {};
+
 			var shouldIntercept = function () {
-				var type = res.getHeader('Content-type');
 				var method = req.method ? req.method.toUpperCase() : 'GET';
-				var acceptedType = type && (type.indexOf('x-shunter+json') !== -1);
 				var acceptedMethod = method === 'GET' || method === 'POST';
 
-				return acceptedType && acceptedMethod;
+				var triggerHeader = trigger.header || 'Content-type';
+				var matchExpression = trigger.matchExpression || 'application/x-shunter\\+json';
+
+				var headerValue = res.getHeader(triggerHeader);
+				var acceptedHeader = headerValue && (headerValue.match(new RegExp(matchExpression, 'i')));
+
+				return acceptedMethod && acceptedHeader;
 			};
 
 			var write = function (chunk) {


### PR DESCRIPTION
Shunter currently requires backend services to include a `Content-type` header with value `application/x-shunter+json` if a response is to be transformed.

Many application frameworks use the `Content-type` for other purposes (e.g. implicit json rendering of object graphs in scalatra) and forcing this requirement can mean service implementations are more complex than they'd otherwise need to be.

This requirement also means service endpoints can't be versioned with [HATEOAS style hypermedia versioning](http://restcookbook.com/Basics/versioning).

This PR allows shunter to be configured to detect an arbitrary response header and trigger rendering or pass-through accordingly. Configuration is optional and the default settings retain the original `Content-type`: `application/x-shunter+json` setup.