### PR TITLE
Extracts snyk test to a separate build run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ matrix:
     - node_js: '6'
       env: LINT=true
 
+    # Run snyk only in Node.js 6.x
+    - node_js: '6'
+      env: SNYK=true
+
     # Run tests in Node.js 4.x
     - node_js: '4'
 
@@ -29,9 +33,7 @@ branches:
     - /^\d+\.\d+\.\d+$/
 
 # Build script
-script:
-  - 'if [ $LINT ]; then npm run lint; fi'
-  - 'if [ ! $LINT ]; then npm run test; fi'
+script: ./build-script
 
 # Updates the dashboard after a successful deployment
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script: ./build-script
 
 # Updates the dashboard after a successful deployment
 after_success:
-  - snyk monitor --org=springernature
+  - if [ $SNYK ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then snyk monitor --org=springernature; fi
 
 # Build notifications
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ xo:
 	@echo "$(C_CYAN)> linting javascript$(C_RESET)"
 	@./node_modules/.bin/xo
 
+snyk:
+	@./node_modules/.bin/snyk test --org=springernature
+
 # Run all tests
 test: lcov-levels
 

--- a/build-script
+++ b/build-script
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eo pipefail
+
+if [ $LINT ]; then
+	npm run lint
+fi
+
+# Disabled for PRs as encrypted variables (which are required for snyk to run) are not propagated to forks
+if [ $SNYK ]; then
+	if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+		npm run snyk
+	else
+		echo "snyk test is disabled on pull requests"
+	fi
+fi
+
+if [ ! $LINT ] && [ ! $SNYK ]; then
+	npm run test
+fi
+
+exit 0;

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
   },
   "scripts": {
     "lint": "make lint",
-    "test": "snyk test && make test"
+    "snyk": "make snyk",
+    "test": "make test"
   },
   "xo": {
     "esnext": false,


### PR DESCRIPTION
This allows us to:
* Run snyk test only once per build
* To avoid running snyk test on pull requests

This prevents problems when merging PRs from forks, as travis doesn't propagate the encrypted variables from the main repo to forks due to security reasons. This meant that snyk wasn't able to authenticate successfully when run from a PR as the token wasn't available.