### PR TITLE
Update getting-started.md removing reference to page colour

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,7 +135,7 @@ You should see a message like this:
 JSON server listening on port 5401
 ```
 
-Leave this running. Now if you re-run `node app.js` in your original terminal window and visit [http://localhost:5400/](http://localhost:5400/) you should see a nice blue page with some form fields!
+Leave this running. Now if you re-run `node app.js` in your original terminal window and visit [http://localhost:5400/](http://localhost:5400/) you should see a nice page with some form fields!
 
 We'll want to provide a sample JSON file that the Shunter application can proxy to. We create sample JSON files in the `data` folder. Add the following to `data/home.json`:
 


### PR DESCRIPTION
Removed the word 'blue' in the page description as the page is no longer blue, hence a little confusing for me at first :)

Seems the change from blue to white was with this [commit to `view/jserve/public/jserve.css`](https://github.com/springernature/shunter/commit/8e5aaf33b365a865045a2d10bb7514a62c18e465#diff-da0cd9c26eefa84f76ce76d4db4f31eb)