### PR TITLE
req.rewrite_url proxy usage

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -186,7 +186,8 @@ module.exports = function (config, renderer) {
 				if (route.host) {
 					route.target = 'http://' + route.host + (route.port ? ':' + route.port : '');
 
-					config.log.info('Proxying request for ' + host + req.url + ' to ' + route.target + req.url);
+					config.log.info('Proxying request for ' + host + req.url + ' to ' + route.target + (req.rewrite_url || req.url));
+					req.url = req.rewrite_url || req.url;
 					req.__proxyTimingFunctionHeadersReceived = config.timer();
 					req.__proxyTimingFunctionBodyReceived = config.timer();
 


### PR DESCRIPTION
### NOTE: pr is created as a base for a feature discussion.

#### feature idea: 
allowing rewrite of the url to be proxied to.

#### minimum impl: 
as seen in processor.js, if a former middleware will set `req.rewrite_url` then it will be used as the proxy target path.


I tested this shortly manually and it seems to work.

let me know if this feature is something your'e interested in, if so I can develop it a little further and write tests etc...