### PR TITLE
Remove colours from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,10 @@
-
-# Color helpers
-C_CYAN=\x1b[34;01m
-C_RESET=\x1b[0m
-
 # Group targets
 all: deps lint lcov-levels
 ci: lint lcov-levels
 
 # Install dependencies
 deps:
-	@echo "$(C_CYAN)> installing dependencies$(C_RESET)"
+	@echo "> Installing dependencies"
 	@npm install
 
 # Run all linters
@@ -17,7 +12,7 @@ lint: xo
 
 # Lint JavaScript
 xo:
-	@echo "$(C_CYAN)> linting javascript$(C_RESET)"
+	@echo "> Linting javascript"
 	@./node_modules/.bin/xo
 
 snyk:
@@ -28,17 +23,16 @@ test: lcov-levels
 
 # Run unit tests
 test-server:
-	@echo "$(C_CYAN)> running server-side unit tests$(C_RESET)"
+	@echo "> Running server-side unit tests"
 	@./node_modules/.bin/mocha --recursive --reporter spec --ui bdd ./tests/server
 
 test-cov:
-	@echo "$(C_CYAN)> checking test coverage $(C_RESET)"
+	@echo "> Checking test coverage"
 	@./node_modules/.bin/istanbul cover node_modules/mocha/bin/_mocha -- --recursive --reporter spec --ui bdd ./tests/server
 
 lcov-levels: test-cov
-	@echo "$(C_CYAN)> checking coverage levels $(C_RESET)"
+	@echo "> Checking coverage levels"
 	@./node_modules/.bin/istanbul check-coverage --statement 80 --branch 80 --function 80
 
 
 .PHONY: test
-


### PR DESCRIPTION
The escape sequences used only work on macOS but not on Linux. This also makes the logs easier to read when using a CI tool.

Last bit of work needed to close #181.