### PR TITLE
Remove gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Shunter does not contain an API client, or any Controller logic (in the [MVC](ht
 [![NPM version][shield-npm]][info-npm]
 [![Node.js version support][shield-node]][info-node]
 [![Build status][shield-build]][info-build]
-[![Dependencies][shield-dependencies]][info-dependencies]
 [![LGPL-3.0 licensed][shield-license]][info-license]
 
 ## Key Features


### PR DESCRIPTION
Because we want to maintain compatibility with 4.x versions of Node we keep some dependencies on older version numbers. These are dependencies that have no known vulnerabilities, and may have officially removed support for older versions of Node.

Having a badge in the README saying "this project has out-of-date dependencies" is neither accurate nor helpful.
