### PR TITLE
Replace sinon.reset() with resetHistory()

### DIFF
--- a/tests/client/lib/sinon.js
+++ b/tests/client/lib/sinon.js
@@ -1348,7 +1348,7 @@ if (!this.sinon && commonJSModule) {
             this.callIds = [];
             if (this.fakes) {
                 for (var i = 0; i < this.fakes.length; i++) {
-                    this.fakes[i].reset();
+                    this.fakes[i].resetHistory();
                 }
             }
         },
@@ -1368,7 +1368,7 @@ if (!this.sinon && commonJSModule) {
             delete proxy.create;
             sinon.extend(proxy, func);
 
-            proxy.reset();
+            proxy.resetHistory();
             proxy.prototype = func.prototype;
             proxy.displayName = name || "spy";
             proxy.toString = sinon.functionToString;

--- a/tests/server/core/dust.js
+++ b/tests/server/core/dust.js
@@ -33,8 +33,8 @@ describe('Template loading', function () {
 		callback = sinon.stub();
 	});
 	afterEach(function () {
-		mockConfig.log.warn.reset();
-		mockRenderer.compileOnDemand.reset();
+		mockConfig.log.warn.resetHistory();
+		mockRenderer.compileOnDemand.resetHistory();
 	});
 
 	it('Should log and gracefully handle missing templates', function () {

--- a/tests/server/core/processor.js
+++ b/tests/server/core/processor.js
@@ -103,7 +103,7 @@ describe('Request processor', function () {
 			mockTimer = sinon.stub().returns(sinon.stub());
 		});
 		afterEach(function () {
-			renderer.render.reset();
+			renderer.render.resetHistory();
 		});
 
 		describe('with default configuration', function () {
@@ -428,7 +428,7 @@ describe('Request processor', function () {
 		});
 
 		afterEach(function () {
-			renderer.renderPartial.reset();
+			renderer.renderPartial.resetHistory();
 		});
 
 		it('Should allow the template to be specified in the url', function () {

--- a/tests/server/core/renderer.js
+++ b/tests/server/core/renderer.js
@@ -86,7 +86,7 @@ describe('Renderer', function () {
 		mockery.deregisterAll();
 		mockery.disable();
 		mockConfig.env.isProduction.returns(true);
-		mockConfig.log.error.reset();
+		mockConfig.log.error.resetHistory();
 	});
 
 	describe('Asset handling', function () {

--- a/tests/server/core/statsd.js
+++ b/tests/server/core/statsd.js
@@ -56,7 +56,7 @@ describe('Logging to statsd', function () {
 	afterEach(function () {
 		mockery.deregisterAll();
 		mockery.disable();
-		mockConfig.log.error.reset();
+		mockConfig.log.error.resetHistory();
 	});
 
 	describe('Native methods', function () {

--- a/tests/server/core/worker.js
+++ b/tests/server/core/worker.js
@@ -84,8 +84,8 @@ describe('Worker process running in production', function () {
 		process.exit.restore();
 	});
 	afterEach(function () {
-		process.exit.reset();
-		config.log.debug.reset();
+		process.exit.resetHistory();
+		config.log.debug.resetHistory();
 	});
 
 	it('Should listen for exit messages', function () {


### PR DESCRIPTION
sinon.reset() is deprecated so after we upgraded from sinon 2.x to 4.x in #256 we started getting deprecation warnings when running our tests:

```
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
```

This replaces the calls to reset() with resetHistory() which has exactly the same functionality and parameters.

Addresses #257.