### PR TITLE
remove some unnecessary usage of path mock in tests

### DIFF
--- a/tests/server/core/dispatch.js
+++ b/tests/server/core/dispatch.js
@@ -3,6 +3,7 @@
 var assert = require('proclaim');
 var sinon = require('sinon');
 var mockery = require('mockery');
+var path = require('path');
 
 var moduleName = '../../../lib/dispatch';
 
@@ -28,7 +29,6 @@ describe('Dispatching response', function () {
 		req.url = '/hello';
 		res = require('../mocks/response');
 
-		mockery.registerMock('path', require('../mocks/path'));
 		mockery.registerMock('mincer', require('../mocks/mincer'));
 		mockery.registerMock('each-module', require('../mocks/each-module'));
 
@@ -44,6 +44,7 @@ describe('Dispatching response', function () {
 			},
 			path: {
 				root: '/',
+				shunterRoot: path.join(path.dirname(__dirname), '../../'),
 				resources: '/resources',
 				publicResources: '/public/resources',
 				themes: '/themes',

--- a/tests/server/core/error-pages.js
+++ b/tests/server/core/error-pages.js
@@ -35,7 +35,6 @@ describe('Templating error pages', function () {
 		mockery.registerMock('./content-type', contentType);
 		res = require('../mocks/response');
 
-		mockery.registerMock('path', require('../mocks/path'));
 		mockery.registerMock('mincer', require('../mocks/mincer'));
 		mockery.registerMock('each-module', require('../mocks/each-module'));
 		mockery.registerMock('./renderer', rendererLib);

--- a/tests/server/core/renderer.js
+++ b/tests/server/core/renderer.js
@@ -3,6 +3,7 @@
 var assert = require('proclaim');
 var sinon = require('sinon');
 var mockery = require('mockery');
+var path = require('path');
 
 var mockConfig = {
 	modules: [
@@ -10,6 +11,7 @@ var mockConfig = {
 	],
 	path: {
 		root: '/',
+		shunterRoot: path.join(path.dirname(__dirname), '../../'),
 		resources: '/resources',
 		publicResources: '/public/resources',
 		themes: '/themes',

--- a/tests/server/core/worker.js
+++ b/tests/server/core/worker.js
@@ -63,7 +63,6 @@ describe('Worker process running in production', function () {
 			warnOnUnregistered: false,
 			warnOnReplace: false
 		});
-		mockery.registerMock('path', require('../mocks/path'));
 		mockery.registerMock('connect', require('../mocks/connect'));
 		mockery.registerMock('body-parser', {json: sinon.stub().returns('JSON')});
 		mockery.registerMock('cookie-parser', sinon.stub().returns('COOKIE'));
@@ -226,7 +225,6 @@ describe('Worker process running outside of production', function () {
 			warnOnReplace: false
 		});
 
-		mockery.registerMock('path', require('../mocks/path'));
 		mockery.registerMock('connect', require('../mocks/connect'));
 		mockery.registerMock('body-parser', {json: sinon.stub().returns('JSON')});
 		mockery.registerMock('cookie-parser', sinon.stub().returns('COOKIE'));


### PR DESCRIPTION
while working on mount-path branch tests, i'm experiencing a lot of hard times because path module is mocked in almost all tests.

i reduced some of these unneeded mock uses, tests still pass :)