### PR TITLE
Mount path

### DIFF
--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -322,6 +322,17 @@ The `assetPath` helper is used to output the correct paths to MD5-fingerprinted 
 <link rel="stylesheet" href="{@assetPath src="main.css"/}"/>
 ```
 
+### The `linkPath` Helper
+
+The `linkPath` helper is used to create a url considering the mount-path
+
+example:
+
+```html
+<form action="{@linkPath src="/search" /}" method="post">
+```
+
+
 ### The `and` Helper
 
 The `and` helper is used to check whether several properties are all truthy. It accepts a `keys` parameter which should be a pipe-separated list of properties to check. If all of them are truthy, the helper block will be output:

--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -331,6 +331,7 @@ example:
 ```html
 <form action="{@linkPath src="/search" /}" method="post">
 ```
+with mount-path `/mounty` it will produce `/mounty/search`
 
 
 ### The `and` Helper

--- a/lib/config.js
+++ b/lib/config.js
@@ -62,6 +62,10 @@ module.exports = function (env, config, args) {
 		.options('compile-on-demand', {
 			type: 'boolean'
 		})
+		.options('mount-path', {
+			type: 'string',
+			default: ''
+		})
 		.options('rewrite-protocol', {
 			type: 'string'
 		})
@@ -80,6 +84,7 @@ module.exports = function (env, config, args) {
 			s: 'Enable logging to syslog',
 			w: 'Preserves whitespace in HTML output',
 			'compile-on-demand': 'Compile templates on demand instead of at application start up, only recommended in development mode',
+			'mount-path': 'defaults to "/", set it to "/bla" to serve requests from "/bla/path"',
 			'rewrite-protocol': 'Rewrite the location protocol on 301, 302, 307 & 308 redirects to http or https',
 			'rewrite-redirect': 'Rewrite the location host/port on 301, 302, 307 & 308 redirects based on requested host/port'
 		})

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -40,6 +40,14 @@ module.exports = function (dust, renderer, config) {
 		return chunk.write(path);
 	};
 
+	dust.helpers.linkPath = function (chunk, context, bodies, params) {
+		var path = renderer.linkPath(context.resolve(params.src));
+		if (!path) {
+			return chunk;
+		}
+		return chunk.write(path);
+	};
+
 	dust.config.whitespace = typeof config === 'object' &&
 		typeof config.argv === 'object' &&
 		config.argv['preserve-whitespace'];

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -62,7 +62,13 @@ module.exports = function (config) {
 		);
 	};
 
+	var linkPath = function (link) {
+		var mountPath = config.argv && (config.argv['mount-path'] || '');
+		return path.join(mountPath, link);
+	};
+
 	environment.registerHelper('asset_path', assetPath);
+	environment.registerHelper('link_path', linkPath);
 	// Assets must be loaded in order (e.g. styles relies on images already being available)
 	var assetTypes = [config.structure.fonts, config.structure.images, config.structure.styles, config.structure.scripts];
 	var themeResourcesPath = config.path.resources;

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -53,11 +53,12 @@ module.exports = function (config) {
 		if (!asset) {
 			return '';
 		}
+		var mountPath = config.argv && (config.argv['mount-path'] || '');
 
 		return (
 			isProduction ?
-				path.join(config.web.publicResources, asset) :
-				path.join(config.web.resources, asset.digestPath)
+				path.join(mountPath, config.web.publicResources, asset) :
+				path.join(mountPath, config.web.resources, asset.digestPath)
 		);
 	};
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -101,6 +101,7 @@ module.exports = function (config) {
 		environment: environment,
 		manifest: manifest,
 		assetPath: assetPath,
+		linkPath: linkPath,
 
 		assetServer: function () {
 			return mincer.createServer(environment);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -51,7 +51,9 @@ module.exports = function (config) {
 	app.use(processor.intercept);
 	app.use(processor.proxy);
 
-	app.listen(config.argv.port, function () {
+	var mountedApp = connect();
+	mountedApp.use(config.argv['mount-path'] || '/', app)
+	mountedApp.listen(config.argv.port, function () {
 		config.log.debug('Worker process ' + process.pid + ' started in ' + config.env.name + ' mode, listening on port ' + config.argv.port);
 	});
 	process.on('uncaughtException', function (err) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -8,6 +8,7 @@ module.exports = function (config) {
 	var serveStatic = require('serve-static');
 	var query = require('qs-middleware');
 	var app = connect();
+	var publicApp = connect();
 
 	var benchmark = require('./benchmark')(config);
 	var renderer = require('./renderer')(config);
@@ -31,11 +32,11 @@ module.exports = function (config) {
 	app.use(config.web.tests, serveStatic(config.path.tests));
 
 	if (config.env.isProduction()) {
-		app.use(config.web.public, serveStatic(config.path.public, {
+		publicApp.use(config.web.public, serveStatic(config.path.public, {
 			maxAge: 1000 * 60 * 60 * 24 * 365
 		}));
 	} else {
-		app.use(config.web.resources, renderer.assetServer());
+		publicApp.use(config.web.resources, renderer.assetServer());
 	}
 
 	config.middleware.forEach(function (args) {
@@ -48,8 +49,10 @@ module.exports = function (config) {
 
 	app.use(processor.timestamp);
 	app.use(processor.shunterVersion);
-	app.use(config.argv['mount-path'] || '/', processor.intercept);
-	app.use(config.argv['mount-path'] || '/', processor.proxy);
+	publicApp.use(processor.intercept);
+	publicApp.use(processor.proxy);
+
+	app.use(config.argv['mount-path'] || '/', publicApp);
 
 	app.listen(config.argv.port, function () {
 		config.log.debug('Worker process ' + process.pid + ' started in ' + config.env.name + ' mode, listening on port ' + config.argv.port);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,6 +1,8 @@
 
 'use strict';
 
+var path = require('path');
+
 module.exports = function (config) {
 	var connect = require('connect');
 	var bodyParser = require('body-parser');
@@ -8,7 +10,6 @@ module.exports = function (config) {
 	var serveStatic = require('serve-static');
 	var query = require('qs-middleware');
 	var app = connect();
-	var publicApp = connect();
 
 	var benchmark = require('./benchmark')(config);
 	var renderer = require('./renderer')(config);
@@ -31,12 +32,15 @@ module.exports = function (config) {
 	app.use(cookieParser());
 	app.use(config.web.tests, serveStatic(config.path.tests));
 
+	var assetMountPath = config.argv && (config.argv['mount-path'] || '');
+	var endpointsMountPath = assetMountPath || '/';
+
 	if (config.env.isProduction()) {
-		publicApp.use(config.web.public, serveStatic(config.path.public, {
+		app.use(path.join(assetMountPath, config.web.public), serveStatic(config.path.public, {
 			maxAge: 1000 * 60 * 60 * 24 * 365
 		}));
 	} else {
-		publicApp.use(config.web.resources, renderer.assetServer());
+		app.use(path.join(assetMountPath, config.web.resources), renderer.assetServer());
 	}
 
 	config.middleware.forEach(function (args) {
@@ -49,10 +53,8 @@ module.exports = function (config) {
 
 	app.use(processor.timestamp);
 	app.use(processor.shunterVersion);
-	publicApp.use(processor.intercept);
-	publicApp.use(processor.proxy);
-
-	app.use(config.argv['mount-path'] || '/', publicApp);
+	app.use(endpointsMountPath, processor.intercept);
+	app.use(endpointsMountPath, processor.proxy);
 
 	app.listen(config.argv.port, function () {
 		config.log.debug('Worker process ' + process.pid + ' started in ' + config.env.name + ' mode, listening on port ' + config.argv.port);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -48,12 +48,10 @@ module.exports = function (config) {
 
 	app.use(processor.timestamp);
 	app.use(processor.shunterVersion);
-	app.use(processor.intercept);
-	app.use(processor.proxy);
+	app.use(config.argv['mount-path'] || '/', processor.intercept);
+	app.use(config.argv['mount-path'] || '/', processor.proxy);
 
-	var mountedApp = connect();
-	mountedApp.use(config.argv['mount-path'] || '/', app)
-	mountedApp.listen(config.argv.port, function () {
+	app.listen(config.argv.port, function () {
 		config.log.debug('Worker process ' + process.pid + ' started in ' + config.env.name + ' mode, listening on port ' + config.argv.port);
 	});
 	process.on('uncaughtException', function (err) {

--- a/tests/server/core/renderer.js
+++ b/tests/server/core/renderer.js
@@ -250,7 +250,7 @@ describe('Renderer', function () {
 
 			var renderer = require(RENDERER_MODULE)(mockConfig);
 
-			require('path').join.returnsArg(1);
+			require('path').join.returnsArg(2);
 			renderer.environment.findAsset.returns({
 				digestPath: 'test-env-md5.css'
 			});
@@ -264,7 +264,7 @@ describe('Renderer', function () {
 
 			var renderer = require(RENDERER_MODULE)(mockConfig);
 
-			require('path').join.returnsArg(1);
+			require('path').join.returnsArg(2);
 
 			var asset = renderer.assetPath('test.css');
 			assert.strictEqual(asset, 'test-prod-md5.css');

--- a/tests/server/core/worker.js
+++ b/tests/server/core/worker.js
@@ -142,11 +142,11 @@ describe('Worker process running in production', function () {
 	});
 
 	it('Should add a middleware to intercept responses from the backend', function () {
-		assert.isTrue(connect().use.calledWith(processor().intercept));
+		assert.isTrue(connect().use.calledWith('/', processor().intercept));
 	});
 
 	it('Should add a middleware to hook up the http proxy', function () {
-		assert.isTrue(connect().use.calledWith(processor().proxy));
+		assert.isTrue(connect().use.calledWith('/', processor().proxy));
 	});
 
 	it('Should mount all additional middleware found in the config', function () {

--- a/tests/server/core/worker.js
+++ b/tests/server/core/worker.js
@@ -142,11 +142,15 @@ describe('Worker process running in production', function () {
 	});
 
 	it('Should add a middleware to intercept responses from the backend', function () {
-		assert.isTrue(connect().use.calledWith('/', processor().intercept));
+		assert.isTrue(connect().use.calledWith(processor().intercept));
 	});
 
 	it('Should add a middleware to hook up the http proxy', function () {
-		assert.isTrue(connect().use.calledWith('/', processor().proxy));
+		assert.isTrue(connect().use.calledWith(processor().proxy));
+	});
+
+	it('Should add a middleware to hook up the publicApp on the mount-path', function () {
+		assert.isTrue(connect().use.calledWith('/', connect()));
 	});
 
 	it('Should mount all additional middleware found in the config', function () {

--- a/tests/server/core/worker.js
+++ b/tests/server/core/worker.js
@@ -141,16 +141,12 @@ describe('Worker process running in production', function () {
 		assert.isTrue(connect().use.calledWith(processor().timestamp));
 	});
 
-	it('Should add a middleware to intercept responses from the backend', function () {
-		assert.isTrue(connect().use.calledWith(processor().intercept));
+	it('Should add a middleware to intercept responses from the backend on default mount path', function () {
+		assert.isTrue(connect().use.calledWith('/', processor().intercept));
 	});
 
-	it('Should add a middleware to hook up the http proxy', function () {
-		assert.isTrue(connect().use.calledWith(processor().proxy));
-	});
-
-	it('Should add a middleware to hook up the publicApp on the mount-path', function () {
-		assert.isTrue(connect().use.calledWith('/', connect()));
+	it('Should add a middleware to hook up the http proxy on default mount path', function () {
+		assert.isTrue(connect().use.calledWith('/', processor().proxy));
 	});
 
 	it('Should mount all additional middleware found in the config', function () {
@@ -285,3 +281,122 @@ describe('Worker process running outside of production', function () {
 		assert.isTrue(renderer().watchDustExtensions.calledOnce);
 	});
 });
+
+
+describe('Worker process running with a set mount-path', function () {
+	var benchmark = null;
+	var connect = null;
+	/* eslint-disable no-unused-vars */
+	var worker = null;
+	/* eslint-enable no-unused-vars */
+	var renderer = null;
+	var processor = null;
+	var config;
+
+	var PORT = 1337;
+	var MOUNTPATH = '/monty';
+
+	before(function () {
+		config = {
+			path: {
+				root: '/',
+				public: '/path/to/public',
+				tests: '/path/to/tests'
+			},
+			web: {
+				resources: '/resources',
+				public: '/public',
+				tests: '/tests'
+			},
+			argv: {
+				'max-child-processes': 1,
+				'mount-path': MOUNTPATH,
+				port: PORT
+			},
+			log: require('../mocks/log'),
+			middleware: [
+				['foo', function () {}],
+				[function () {}]
+			],
+			env: {
+				name: 'production',
+				isProduction: function(){return true},
+				isDevelopment: function(){return false}
+			}
+		};
+
+		renderer = require('../mocks/renderer');
+		processor = require('../mocks/processor');
+		benchmark = require('../mocks/benchmark');
+
+		sinon.spy(process, 'on');
+		sinon.stub(process, 'exit');
+
+		mockery.enable({
+			useCleanCache: true,
+			warnOnUnregistered: false,
+			warnOnReplace: false
+		});
+		mockery.registerMock('connect', require('../mocks/connect'));
+		mockery.registerMock('body-parser', {json: sinon.stub().returns('JSON')});
+		mockery.registerMock('cookie-parser', sinon.stub().returns('COOKIE'));
+		mockery.registerMock('serve-static', sinon.stub());
+		mockery.registerMock('qs-middleware', sinon.stub().returns('QUERY'));
+		mockery.registerMock('./renderer', renderer);
+		mockery.registerMock('./processor', processor);
+		mockery.registerMock('./benchmark', benchmark);
+
+		connect = require('connect');
+
+		worker = require('../../../lib/worker')(config);
+	});
+	after(function () {
+		mockery.deregisterAll();
+		mockery.disable();
+		process.on.restore();
+		process.exit.restore();
+	});
+	afterEach(function () {
+		process.exit.resetHistory();
+		config.log.debug.resetHistory();
+	});
+
+
+	it('Should add a middleware to intercept responses from the backend on mount path', function () {
+		assert.isTrue(connect().use.calledWith(MOUNTPATH, processor().intercept));
+	});
+
+	it('Should add a middleware to hook up the http proxy on mount path', function () {
+		assert.isTrue(connect().use.calledWith(MOUNTPATH, processor().proxy));
+	});
+
+	it('Should load the appropriate assets in production mode on mount path', function () {
+		assert.isTrue(connect().use.calledWith(MOUNTPATH + '/public'));
+		assert.isTrue(require('serve-static').calledWith('/path/to/public'));
+		assert.isTrue(renderer().assetServer.calledOnce);
+	});
+
+	it('Should mount all additional middleware found in the config', function () {
+		assert.isTrue(connect().use.calledWithExactly(config.middleware[0][0], config.middleware[0][1]));
+		assert.isTrue(connect().use.calledWithExactly(config.middleware[1][0]));
+	});
+
+	it('Should set up a ping end point', function () {
+		assert.isTrue(connect().use.calledWith('/ping', processor().ping));
+	});
+
+	it('Should set up an end point for the template api', function () {
+		assert.isTrue(connect().use.calledWith('/template', processor().api));
+	});
+
+	it('Should listen on the specified port', function () {
+		assert.isTrue(connect().listen.calledOnce);
+		assert.isTrue(connect().listen.calledWith(PORT));
+	});
+
+	it('Should log a message on start up', function () {
+		connect().listen.firstCall.yield();
+		assert.isTrue(config.log.debug.calledOnce);
+	});
+});
+


### PR DESCRIPTION
## the problem
when shunter app is not mounted at root `/` of a  of a domain, but rather on a sub path, and possibly sharing the main domain with other apps (on sub paths), this can cause problems with
- asset path rendering : the assetPath helper will return assets on `/` ( + `config.web.publicResources`) and not on the sub path
- proxied calls to backend : the proxied calls will contain the path, which the backend might not care about (example: simple rest api on `/` that serves multiple apps)

its possible to solve these issues by fiddling with `config.web.publicResources` (and other config values) and by introducing a reverse proxy in between shunter & backend.

but its even easier to just let shunter be aware of the mount-path :)

## solution

this pr introduces the mount-path arg and the linkPath helper.
setting mount-path will mount intercept, proxy and static assets handling middlewares at the given mount-path; and will also consider mount-path when calculating asset paths in assetPath helper.

