### PR TITLE
Fix worker test stub behaviour that was causing child tests to fail

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,13 @@
 ## 4.11.4 (2018-06-25)
 
 * Update `wd` and `saucelabs`
+* Mount path as config option (Thanks @samzilverberg)
+* remove some unnecessary usage of path mock in tests
+* Replace `sinon.reset()` with `resetHistory()`
+* Remove gemnasium badge from README
+* Remove `snyk test` from travis' test matrix
+* Upgrade sinon to 4.x. Fixes #253
+* Replace xo with eslint and the springernature cfg
 
 ## 4.11.3 (2018-02-16)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,8 @@
 
 # History
 
+* Fix worker test stub behaviour that was causing child tests to fail
+
 ## 4.11.4 (2018-06-25)
 
 * Update `wd` and `saucelabs`

--- a/tests/server/core/worker.js
+++ b/tests/server/core/worker.js
@@ -83,7 +83,7 @@ describe('Worker process running in production', function () {
 		process.exit.restore();
 	});
 	afterEach(function () {
-		process.exit.resetHistory();
+		process.exit.reset();
 		config.log.debug.resetHistory();
 	});
 


### PR DESCRIPTION
In sinon 4.x, `reset()` has been deprecated for spies and replaced with `resetHistory()`.

As part of `534d1bd` a call to `stub.reset()` was wrongly replaced with `stub.resetHistory()`. `reset()` is not deprecated for stubs, only for spies, so we don't want to change this.

This was causing the client tests in some child apps to fail.

Also fixes missing history from previous 4.11.4 release.