### PR TITLE
Remove deprecated Buffer() constructor

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,8 @@
 
 # History
 
+* Remove deprecated Buffer() constructor
+
 ## 4.11.5 (2018-07-09)
 
 * Fix worker test stub behaviour introduced in `4.11.4` that was causing child tests to fail

--- a/tests/server/core/processor.js
+++ b/tests/server/core/processor.js
@@ -140,7 +140,7 @@ describe('Request processor', function () {
 				processor.intercept(req, res, callback);
 
 				res.writeHead();
-				res.write(new Buffer('{"foo":"bar"}'));
+				res.write(Buffer.from('{"foo":"bar"}'));
 				res.end();
 
 				assert.isTrue(renderer.render.calledOnce);
@@ -168,7 +168,7 @@ describe('Request processor', function () {
 				res.getHeader.withArgs('render-with').returns('shunter');
 				processor.intercept(req, res, sinon.stub());
 				res.writeHead();
-				res.write(new Buffer('{"foo":"bar"}'));
+				res.write(Buffer.from('{"foo":"bar"}'));
 				res.end();
 
 				assert.isTrue(renderer.render.calledOnce);
@@ -218,7 +218,7 @@ describe('Request processor', function () {
 			processor.intercept(req, res, callback);
 
 			res.writeHead();
-			res.write(new Buffer('{"foo":"bar"}'));
+			res.write(Buffer.from('{"foo":"bar"}'));
 			res.end();
 
 			assert.equal(renderer.render.callCount, 0);
@@ -244,8 +244,8 @@ describe('Request processor', function () {
 			processor.intercept(req, res, callback);
 
 			res.writeHead();
-			res.write(new Buffer('{"foo":'));
-			res.write(new Buffer('"bar"}'));
+			res.write(Buffer.from('{"foo":'));
+			res.write(Buffer.from('"bar"}'));
 			res.end();
 
 			assert.isTrue(renderer.render.calledOnce);
@@ -255,12 +255,12 @@ describe('Request processor', function () {
 		it('Should safely reconstruct multibyte characters that are split between writes', function () {
 			var value = 'abc⩽def';
 			var raw = '{"foo":"' + value + '"}';
-			var source = new Buffer(raw);
+			var source = Buffer.from(raw);
 			var length = Buffer.byteLength(raw);
 			var firstChunkLength = raw.indexOf('c') + 2; // Split in the middle of the ⩽ character
 			var secondChunkLength = length - firstChunkLength;
-			var firstChunk = new Buffer(firstChunkLength);
-			var secondChunk = new Buffer(secondChunkLength);
+			var firstChunk = Buffer.allocUnsafe(firstChunkLength);
+			var secondChunk = Buffer.allocUnsafe(secondChunkLength);
 			source.copy(firstChunk, 0, 0, firstChunkLength);
 			source.copy(secondChunk, 0, firstChunkLength);
 
@@ -307,7 +307,7 @@ describe('Request processor', function () {
 			processor.intercept(req, res, callback);
 
 			res.writeHead();
-			res.write(new Buffer('{"foo":"bar"}'));
+			res.write(Buffer.from('{"foo":"bar"}'));
 			res.end();
 
 			renderer.render.firstCall.yield(null, 'Content');
@@ -338,7 +338,7 @@ describe('Request processor', function () {
 			processor.intercept(req, res, callback);
 
 			res.writeHead(401);
-			res.write(new Buffer('{"foo":"bar"}'));
+			res.write(Buffer.from('{"foo":"bar"}'));
 			res.end();
 
 			renderer.render.firstCall.yield(null, 'Content');
@@ -375,7 +375,7 @@ describe('Request processor', function () {
 			processor.intercept(req, res, callback);
 
 			res.writeHead();
-			res.write(new Buffer('{"foo":bar"}'));
+			res.write(Buffer.from('{"foo":bar"}'));
 			assert.doesNotThrow(function () {
 				res.end();
 			});


### PR DESCRIPTION
This removes all the calls to the deprecated `Buffer()` constructor and replaces them with `Buffer.from()` (for strings) and `Buffer.allocUnsafe()` (for numbers). These are currently used in tests only, so using `allocUnsafe()` doesn't pose a security risk.

The `Buffer()` function and `new Buffer()` constructor have been deprecated since node 6 due to API usability issues that can potentially lead to accidental security issues. As of v10.0.0, a deprecation warning is printed at runtime when `--pending-deprecation` is used or when the calling code is outside node_modules.

Ref: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor