### PR TITLE
Update testing documentation

### DIFF
--- a/docs/usage/testing.md
+++ b/docs/usage/testing.md
@@ -42,6 +42,14 @@ describe('Foo bar', function() {
 
 In the `helper.render` callback, the `$` parameter is a [Cheerio](https://github.com/cheeriojs/cheerio) instance which allows you to use jQuery-like functions to access the render output. The `output` parameter contains the full output as a string.
 
+If you need you can pass extra arguments to the `render` function:
+
+```js
+helper.render(template, req, res, data, callback);
+```
+
+This could be useful in cases where you want to test request objects. For example: custom headers or cookies.
+
 When testing templates that are in subfolders, be sure to pass in any subfolders in the same way that you'd include a partial
 
 ```js


### PR DESCRIPTION
I came across this very case on my project where I had to test a template that had to display some content based on a cookie value.
I had to dig into Shunter code to figure out that you can actually pass the `req` to the `render` method.

Hopefully this will make it clear for other devs as well!

Thanks!