### PR TITLE
hikes request dep to 2.87

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "promised-io": "~0.3.0",
     "qs": "~6.5.1",
     "qs-middleware": "~1.0.3",
-    "request": "~2.83.0",
+    "request": "~2.87.0",
     "saucelabs": "~1.5.0",
     "serve-static": "~1.13.0",
     "statsd-client": "~0.2.0",


### PR DESCRIPTION
Hikes `request` dependency to 2.87. Snyk says;

> ✗ Medium severity vulnerability found on cryptiles@3.1.2
> - desc: Insecure Randomness
> - info: https://snyk.io/vuln/npm:cryptiles:20180710
> - from: shunter@4.11.5 > request@2.83.0 > hawk@6.0.2 > cryptiles@3.1.2
> Upgrade direct dependency request@2.83.0 to request@2.84.0 (triggers upgrades to hawk@7.0.7 > cryptiles@4.1.2)

request @ 2.87 actually drops the requirement for `hawk` entirely, so hopefully a win-win.