### PR TITLE
Use current timestamp for x-shunter-deploy-timestamp header in develo…

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -46,7 +46,7 @@ module.exports = function (config, renderer) {
 
 	var processor = {
 		timestamp: function (req, res, next) {
-			req.headers['X-Shunter-Deploy-Timestamp'] = deployTimestamp;
+			req.headers['X-Shunter-Deploy-Timestamp'] = config.env.isDevelopment() ? Date.now() : deployTimestamp;
 			next();
 		},
 

--- a/tests/server/core/processor.js
+++ b/tests/server/core/processor.js
@@ -11,7 +11,8 @@ var mockConfig = {
 	timer: sinon.stub().returns(sinon.stub()),
 	env: {
 		tier: sinon.stub(),
-		host: sinon.stub().returns('ci')
+		host: sinon.stub().returns('ci'),
+		isDevelopment: sinon.stub().returns(false)
 	},
 	argv: {}
 };
@@ -77,8 +78,18 @@ describe('Request processor', function () {
 			assert.equal(req.headers['X-Shunter-Deploy-Timestamp'], '1234567890');
 			assert.equal(req.url, '/foo');
 			assert.isTrue(next.calledOnce);
+		});
 
-			mockConfig.argv = {};
+		it('Should override the X-Shunter-Deploy-Timestamp with the current time in dev mode', function() {
+			mockConfig.env.isDevelopment.returns(true);
+			var processor = require(moduleName)(mockConfig, {});
+			var next = sinon.stub();
+
+			req.url = '/foo';
+			processor.timestamp(req, {}, next);
+			assert.notEqual(req.headers['X-Shunter-Deploy-Timestamp'], '1234567890');
+			assert.equal(req.url, '/foo');
+			assert.isTrue(next.calledOnce);
 		});
 
 		it('Should add a header X-Shunter with the Shunter version being used', function () {


### PR DESCRIPTION
…pment mode

This header is supposed to be used as a hint to the backend that templates may have changed and to use this information when figuring out whether to send a not modified response or not. In development we probably want to force-rendering of the templates on every request so this changes it to use the current timestamp in this case.