### PR TITLE
Update from mocha v3 to v6 and fix hanging test

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -12,6 +12,7 @@ module.exports = function (extension) {
 		var Gaze = require('gaze');
 		var watchedDirs = (typeof directories === 'string') ? constructGlob(directories) : directories.map(constructGlob);
 		var watcher = new Gaze(watchedDirs);
+
 		watcher.on('added', function (path) {
 			watcher.emit('fileCreated', path);
 		});
@@ -19,6 +20,7 @@ module.exports = function (extension) {
 			watcher.emit('fileModified', path);
 		});
 		watcher.on('error', log.error);
+
 		return watcher;
 	};
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-unicorn": "^4.0.3",
-    "mocha": "^3.0.0",
+    "mocha": "^6.2.0",
     "mocha-phantomjs-core": "~2.1.0",
     "mockery": "^2.0.0",
     "node-sass": "^4.5.3",

--- a/tests/server/core/watcher.js
+++ b/tests/server/core/watcher.js
@@ -60,6 +60,9 @@ describe('Watcher watchTree', function () {
 			wt = watchTree('foo', require('../mocks/log'));
 			emitSpy = sinon.spy(wt, 'emit');
 		});
+		afterEach(function () {
+			wt.close();
+		});
 		it('Should emit a fileCreated event when a file is created', function () {
 			wt.emit('added', 'foopath');
 			assert(emitSpy.calledWith('fileCreated', 'foopath'));


### PR DESCRIPTION
Mocha 4 introduces a change where Mocha won't force the process to exit once all tests complete. There was a watcher being set up in a unit test that wasn't being closed properly, and this was causing Mocha to hang indefinitely with this new behaviour.

Also minor whitespace fixing.