### PR TITLE
Upgrade sinon to v7 and remove unused tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "node-sass": "^4.5.3",
     "nyc": "^14.1.1",
     "proclaim": "^3.0.0",
-    "sinon": "^4.0.0"
+    "sinon": "^7.0.0"
   },
   "main": "./lib/shunter.js",
   "bin": {

--- a/tests/server/core/renderer.js
+++ b/tests/server/core/renderer.js
@@ -177,23 +177,6 @@ describe('Renderer', function () {
 			assert.strictEqual(inputFilter().add.withArgs(filter).callCount, 2);
 		});
 
-		// It('Should configure the asset paths in the correct order', function() {
-		// 	require('fs').readdirSync.returns([]);
-		// 	require('fs').existsSync.returns(true);
-		// 	require('path').join.returnsArg(1);
-
-		// 	var renderer = require(RENDERER_MODULE)(mockConfig);
-		// 	assert.strictEqual(renderer.environment.appendPath.callCount, 8);
-		// 	assert.isTrue(renderer.environment.appendPath.firstCall.calledWith('fonts'));
-		// 	assert.isTrue(renderer.environment.appendPath.secondCall.calledWith('img'));
-		// 	assert.isTrue(renderer.environment.appendPath.thirdCall.calledWith('css'));
-		// 	assert.isTrue(renderer.environment.appendPath.lastCall.calledWith('js'));
-		// });
-
-		// Commenting out for now; we no longer deal with themes, but we may want to replicate
-		// similar tests when we rewrite the asset loading logic for the new application structure
-		//
-
 		it('Should append the asset paths for the host app, in the correct order (i.e. on odd iterations)', function () {
 			require('fs').existsSync.returns(true);
 			require('fs').mockStatReturn.isDirectory.returns(true);
@@ -205,19 +188,6 @@ describe('Renderer', function () {
 			assert.isTrue(renderer.environment.appendPath.thirdCall.calledWith('img'));
 			assert.isTrue(renderer.environment.appendPath.getCall(4).calledWith('css'));
 			assert.isTrue(renderer.environment.appendPath.getCall(6).calledWith('js'));
-		});
-
-		it('Should configure the asset paths for the modules after the host app ones, in the correct order (i.e. on even iterations)', function () {
-			require('fs').existsSync.returns(true);
-			require('fs').mockStatReturn.isDirectory.returns(true);
-			require('path').join.returnsArg(2);
-
-			var renderer = require(RENDERER_MODULE)(mockConfig);
-			assert.strictEqual(renderer.environment.appendPath.callCount, 8);
-			assert.isTrue(renderer.environment.appendPath.secondCall.calledWith('fonts'));
-			assert.isTrue(renderer.environment.appendPath.getCall(3).calledWith('img'));
-			assert.isTrue(renderer.environment.appendPath.getCall(5).calledWith('css'));
-			assert.isTrue(renderer.environment.appendPath.getCall(7).calledWith('js'));
 		});
 
 		it('Should not configure asset paths for files in a module that is not explicitly included', function () {


### PR DESCRIPTION
Removes two renderer tests:

* One of the tests has been commented out for years
* The other tests relates to themes (which shunter doesn't not support) and hasn't been working as expected for 5 years or so. Only a change in sinon 6.1.2 revealed that this test was indeed broken.