### PR TITLE
Pin yargs to version 7.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "wd": "~1.10.0",
     "winston": "~2.3.0",
     "winston-syslog": "~1.2.0",
-    "yargs": "~7.1.0"
+    "yargs": "7.1.0"
   },
   "devDependencies": {
     "@springernature/eslint-config": "^1.0.0",


### PR DESCRIPTION
The yargs team released a version 7.1.1 with a version of yargs-parser that seems to cause an error at startup:
```
args.hasOwnProperty is not a function
```

This commit fixed the yargs version to 7.1.0, which should fix these errors for everyone.