### PR TITLE
Fix start up error when using yargs 7.1.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,9 @@
 
 # History
 
+## 4.13.5 (2021-03-30)
+* Fixes an issue that would prevent apps from starting when using `yargs` 7.1.1+
+
 ## 4.13.4 (2021-01-19)
 
 * Fixes an issue with recent `http-proxy` update that could have broken proxying for some apps. See #339

--- a/lib/config.js
+++ b/lib/config.js
@@ -98,7 +98,7 @@ module.exports = function (env, config, args) {
 			var exclude = ['_', '$0'];
 
 			Object.keys(argv).forEach(function (key) {
-				if (exclude.indexOf(key) === -1 && !args.hasOwnProperty(key)) {
+				if (exclude.indexOf(key) === -1 && !Object.prototype.hasOwnProperty.call(args, key)) {
 					throw new Error('Unknown argument error: `' + key + '` is not a valid argument');
 				}
 			});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shunter",
-  "version": "4.13.4",
+  "version": "4.13.5",
   "license": "LGPL-3.0",
   "description": "A Node.js application built to read JSON and translate it into HTML",
   "keywords": [
@@ -82,7 +82,7 @@
     "wd": "~1.10.0",
     "winston": "~2.3.0",
     "winston-syslog": "~1.2.0",
-    "yargs": "7.1.0"
+    "yargs": "7.1.1"
   },
   "devDependencies": {
     "@springernature/eslint-config": "^1.0.0",


### PR DESCRIPTION
From version 7.1.1 of yargs it seems the args object has a null prototype so calling args.hasOwnProperty will error. 