### PR TITLE
Remove support for node 10 and 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,11 @@ language: node_js
 matrix:
   include:
     # Run only the linting in Node.js 10.x
-    - node_js: '10'
+    - node_js: '12'
       env: LINT=true
 
     # Run tests in all supported Node.js Stable/LTS (10, 12 and 14)
-    - node_js: '10'
     - node_js: '12'
-    - node_js: '14'
 
 # Build script
 script: ./build-script

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/springernature/shunter",
   "bugs": "https://github.com/springernature/shunter/issues",
   "engines": {
-    "node": ">=10"
+    "node": "12"
   },
   "dependencies": {
     "async": "~3.1.0",


### PR DESCRIPTION
Remove Node.js v10 and v14 from the test matrix:

* Node.js v10 is now unsupported as of 30th Apr 2021.
* Dustjs uses v1 of fsevents as an optional dependency, but it looks like this version of fsevents is not compatible with node v14:
```
npm WARN deprecated fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
```

Also updates `version` field in the `package.json` file to reflect the current support status.