### PR TITLE
supports default branch rename, fixes links

### DIFF
--- a/.github/workflows/test-on-push-and-pull.yml
+++ b/.github/workflows/test-on-push-and-pull.yml
@@ -5,9 +5,9 @@ name: Node.js CI tests
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -164,7 +164,7 @@
 
 * Upgrade `qs` to `6.4.0`. Fixes https://snyk.io/vuln/npm:qs:20170213
 * Updates several dependencies that include the vulnerable `qs` package.
-* Replace all package version numbers in the package.json with the standard form as per our new dependency management guidelines in the playbook: https://github.com/springernature/frontend-playbook/blob/master/practices/dependency-management.md#specifying-versions-of-dependencies
+* Replace all package version numbers in the package.json with the standard form as per our new dependency management guidelines in the playbook: https://github.com/springernature/frontend-playbook/blob/main/practices/dependency-management.md#specifying-versions-of-dependencies
 * Package.json cleanup
 
 ## 4.4.0 (2017-03-02)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ We also label [issues that might be a good starting-point][starter-issues] for n
 ## License
 
 Shunter is licensed under the [Lesser General Public License (LGPL-3.0)][info-license].
-Copyright &copy; 2015, Springer Nature
+
+Copyright &copy; 2022, Springer Nature
 
 [brew]: http://mxcl.github.com/homebrew/
 [node]: https://nodejs.org/

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ It helps you create a loosely-coupled front end application which can serve traf
 
 Shunter does not contain an API client, or any Controller logic (in the [MVC](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller) sense). Instead, Shunter simply proxies requests to a back end server, then:
 
-1. If the back end wants Shunter to render the response, it returns the application state as JSON, served with a certain HTTP header. This initiates the templating process in Shunter.  
+1. If the back end wants Shunter to render the response, it returns the application state as JSON, served with a certain HTTP header. This initiates the templating process in Shunter.
 ![Diagram of Shunter intercepting a JSON backend reply](docs/img/shunter-json-intercept.png)
 
-2. If the back end wishes to serve the response, it omits the header and Shunter proxies the request back to the client.  
+2. If the back end wishes to serve the response, it omits the header and Shunter proxies the request back to the client.
 ![Diagram of Shunter proxying a backend reply](docs/img/shunter-backend-proxy.png)
 
-3. Shunter is also able to serve resources like CSS, JS, or images bundled with the templates as part of your application.  
+3. Shunter is also able to serve resources like CSS, JS, or images bundled with the templates as part of your application.
 ![Diagram of Shunter serving a bundled asset](docs/img/shunter-assets.png)
 
 [![NPM version][shield-npm]][info-npm]
@@ -90,7 +90,7 @@ We also label [issues that might be a good starting-point][starter-issues] for n
 
 ## License
 
-Shunter is licensed under the [Lesser General Public License (LGPL-3.0)][info-license].  
+Shunter is licensed under the [Lesser General Public License (LGPL-3.0)][info-license].
 Copyright &copy; 2015, Springer Nature
 
 [brew]: http://mxcl.github.com/homebrew/
@@ -98,7 +98,7 @@ Copyright &copy; 2015, Springer Nature
 [npm]: https://www.npmjs.com/
 [nvm]: https://github.com/nvm-sh/nvm
 [starter-issues]: https://github.com/springernature/shunter/labels/good-starter-issue
-[support]: https://github.com/springernature/frontend-playbook/blob/master/practices/open-source-support.md
+[support]: https://github.com/springernature/frontend-playbook/blob/main/practices/open-source-support.md
 
 [info-coverage]: https://coveralls.io/github/springernature/shunter
 [info-dependencies]: https://gemnasium.com/springernature/shunter

--- a/docs/contributing-to-shunter.md
+++ b/docs/contributing-to-shunter.md
@@ -4,32 +4,32 @@ This guide is here to help new developers get started on contributing to the dev
 
 If you're looking for information on how to _use_ Shunter, please see the [documentation](index.md).
 
-* [Library Structure](#library-structure)
-* [Use of GitHub Issues](#issue-tracking)
-* [Writing Unit Tests](#testing)
-* [Static Analysis](#static-analysis)
-* [Versioning](#versioning-and-releases)
+- [Library structure](#library-structure)
+- [Issue tracking](#issue-tracking)
+- [Testing](#testing)
+- [Static analysis](#static-analysis)
+- [Versioning and releases](#versioning-and-releases)
 
 ## Library structure
 
 The main files that comprise Shunter live in the `lib` folder. Shunter has been broken up into several smaller modules which serve different purposes. We'll outline the basics here:
 
-* [`benchmark.js`](https://github.com/springernature/shunter/blob/master/lib/benchmark.js) exports a middleware which is used to benchmark request times.
-* [`config.js`](https://github.com/springernature/shunter/blob/master/lib/config.js) contains the default application configuration and code to merge defaults with the user config.
-* [`content-type.js`](https://github.com/springernature/shunter/blob/master/lib/content-type.js) is a small utility used to infer the content-type of a URL based on its file extension.
-* [`dispatch.js`](https://github.com/springernature/shunter/blob/master/lib/dispatch.js) applies output filters to the content and returns the response to the client.
-* [`dust.js`](https://github.com/springernature/shunter/blob/master/lib/dust.js) handles the application's Dust instance and registers some default helpers.
-* [`input-filter.js`](https://github.com/springernature/shunter/blob/master/lib/input-filter.js) handles the loading and application of input filters.
-* [`output-filter.js`](https://github.com/springernature/shunter/blob/master/lib/output-filter.js) handles the loading and application of output filters.
-* [`processor.js`](https://github.com/springernature/shunter/blob/master/lib/processor.js) exports the middlewares Shunter uses for interacting with the request/response cycle.
-* [`query.js`](https://github.com/springernature/shunter/blob/master/lib/query.js) exports a middleware which attaches a parsed query string object to the request.
-* [`renderer.js`](https://github.com/springernature/shunter/blob/master/lib/renderer.js) handles compilation and rendering of Dust templates.
-* [`router.js`](https://github.com/springernature/shunter/blob/master/lib/router.js) parses the route configuration and routes requests to the correct back end application.
-* [`server.js`](https://github.com/springernature/shunter/blob/master/lib/server.js) manages the lifecycle of the worker processes Shunter uses to serve requests.
-* [`shunter.js`](https://github.com/springernature/shunter/blob/master/lib/shunter.js) exports everything required for a Shunter application, and is the main entry-point.
-* [`statsd.js`](https://github.com/springernature/shunter/blob/master/lib/statsd.js) wraps a StatsD instance which is used to record application metrics.
-* [`watcher.js`](https://github.com/springernature/shunter/blob/master/lib/watcher.js) is a utility to watch a tree of files and reload them on change.
-* [`worker.js`](https://github.com/springernature/shunter/blob/master/lib/worker.js) creates a Connect app to handle requests with the Shunter middlewares added to the stack. Instances of this app are run in each process managed by `server.js`.
+* [`benchmark.js`](https://github.com/springernature/shunter/blob/main/lib/benchmark.js) exports a middleware which is used to benchmark request times.
+* [`config.js`](https://github.com/springernature/shunter/blob/main/lib/config.js) contains the default application configuration and code to merge defaults with the user config.
+* [`content-type.js`](https://github.com/springernature/shunter/blob/main/lib/content-type.js) is a small utility used to infer the content-type of a URL based on its file extension.
+* [`dispatch.js`](https://github.com/springernature/shunter/blob/main/lib/dispatch.js) applies output filters to the content and returns the response to the client.
+* [`dust.js`](https://github.com/springernature/shunter/blob/main/lib/dust.js) handles the application's Dust instance and registers some default helpers.
+* [`input-filter.js`](https://github.com/springernature/shunter/blob/main/lib/input-filter.js) handles the loading and application of input filters.
+* [`output-filter.js`](https://github.com/springernature/shunter/blob/main/lib/output-filter.js) handles the loading and application of output filters.
+* [`processor.js`](https://github.com/springernature/shunter/blob/main/lib/processor.js) exports the middlewares Shunter uses for interacting with the request/response cycle.
+* [`query.js`](https://github.com/springernature/shunter/blob/main/lib/query.js) exports a middleware which attaches a parsed query string object to the request.
+* [`renderer.js`](https://github.com/springernature/shunter/blob/main/lib/renderer.js) handles compilation and rendering of Dust templates.
+* [`router.js`](https://github.com/springernature/shunter/blob/main/lib/router.js) parses the route configuration and routes requests to the correct back end application.
+* [`server.js`](https://github.com/springernature/shunter/blob/main/lib/server.js) manages the lifecycle of the worker processes Shunter uses to serve requests.
+* [`shunter.js`](https://github.com/springernature/shunter/blob/main/lib/shunter.js) exports everything required for a Shunter application, and is the main entry-point.
+* [`statsd.js`](https://github.com/springernature/shunter/blob/main/lib/statsd.js) wraps a StatsD instance which is used to record application metrics.
+* [`watcher.js`](https://github.com/springernature/shunter/blob/main/lib/watcher.js) is a utility to watch a tree of files and reload them on change.
+* [`worker.js`](https://github.com/springernature/shunter/blob/main/lib/worker.js) creates a Connect app to handle requests with the Shunter middlewares added to the stack. Instances of this app are run in each process managed by `server.js`.
 
 ## Issue tracking
 
@@ -43,7 +43,7 @@ If you're logging a new bug or feature request, please be as descriptive as poss
 
 ## Testing
 
-We maintain a fairly complete set of test suites for Shunter, and these get run on every pull-request and commit to master. It's useful to also run these locally when you're working on Shunter.
+We maintain a fairly complete set of test suites for Shunter, and these get run on every pull-request and commit to the default branch. It's useful to also run these locally when you're working on Shunter.
 
 To run all the tests, you can use:
 
@@ -75,4 +75,4 @@ Most of the time, one of the core developers will decide when a release is ready
 
 Shunter is versioned with [semver](http://semver.org/). You should read through the [semver documentation](http://semver.org) if you're versioning Shunter.
 
-You can check the details of our release process in our [Open Source support guide](https://github.com/springernature/frontend-playbook/blob/master/practices/open-source-support.md#release-process) in the [Springer Nature frontend playbook](https://github.com/springernature/frontend-playbook).
+You can check the details of our release process in our [Open Source support guide](https://github.com/springernature/frontend-playbook/blob/main/practices/open-source-support.md#release-process) in the [Springer Nature frontend playbook](https://github.com/springernature/frontend-playbook).

--- a/docs/migration/4.0.md
+++ b/docs/migration/4.0.md
@@ -24,4 +24,4 @@ If you're using the default logger, [Winston](https://github.com/winstonjs/winst
 
 ## EJS filters
 
-The update from EJS version 0.x to 2.x carries with it the [potential for breaking changes](https://github.com/mde/ejs/blob/master/CHANGELOG.md#v201-2015-01-02); most significantly the removal of the filters feature.
+The update from EJS version 0.x to 2.x carries with it the [potential for breaking changes](https://github.com/mde/ejs/blob/main/CHANGELOG.md#v201-2015-01-02); most significantly the removal of the filters feature.


### PR DESCRIPTION
 - I just renamed the default branch on origin, so a CI file needs updating to reflect that
 - fixes some GH links in the docs that contained the old default branch name
 - also fixes some external links for the same reason
 - there are also some whitespace and markdown list style changes, sorry for the noise! 🔈 