### PR TITLE
CI schedule & npm installation method

### DIFF
--- a/.github/workflows/test-on-push-and-pull.yml
+++ b/.github/workflows/test-on-push-and-pull.yml
@@ -31,7 +31,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
 
-    - run: npm i
+    # this is a library, not an app, so ignore the package-lock
+    - run: npm install --package-lock false
     - if: ${{ matrix.LINT }}
       run: npm run lint
 

--- a/.github/workflows/test-on-push-and-pull.yml
+++ b/.github/workflows/test-on-push-and-pull.yml
@@ -1,5 +1,6 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# This workflow will do a clean installation of node dependencies, cache/restore them,
+#  build the source code and run tests across different versions of node
+# https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Node.js CI tests
 
@@ -8,10 +9,11 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  schedule:
+    - cron: '0 7 * * *'
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -29,7 +31,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
 
-    - run: npm ci
+    - run: npm i
     - if: ${{ matrix.LINT }}
       run: npm run lint
 

--- a/.github/workflows/test-on-push-and-pull.yml
+++ b/.github/workflows/test-on-push-and-pull.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches: [ "main" ]
   schedule:
+    # 7am UTC daily
     - cron: '0 7 * * *'
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ config/routes/*.json
 coverage/*
 min.js
 node_modules
-package-lock.json
 public/resources
 shunter-*.tgz
 tests/mock-app/public/

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,15 @@
-node_modules
-# package-lock.json
-public/resources
-tests/mock-app/public/
-min.js
+.DS_Store
+.idea
+.nyc_output
+*.iml
 *.log
 *.pid
 config/routes/*.json
 coverage/*
-timestamp.json
-.DS_Store
+min.js
+node_modules
+package-lock.json
+public/resources
 shunter-*.tgz
-.idea
-*.iml
-.nyc_output
+tests/mock-app/public/
+timestamp.json


### PR DESCRIPTION
 - tidy `.gitignore` (no meaningful changes)
 - run build & tests at 7am UTC daily
 - run `npm i` not `npm ci` in CI and ignore `package-lock.json`  
 
We run `npm i` not `npm ci` in CI (and ignore the  `package-lock.json`) because shunter is a library, not an application. In the event of a change anywhere in the dependency tree breaking the build, or tests, we want to know ASAP to reflect what our users experience. 

Running `npm ci` would result in a deterministic install that would not give us that insight.

This means we do not need the `package-lock.json` to be in git; but it's [required](https://github.com/actions/setup-node/issues/581) for `actions/setup-node` GH Action to work.
